### PR TITLE
게시글 제목 텍스트 부분 클릭시 서버요청 2번 하는 버그 수정

### DIFF
--- a/js/nariya.js
+++ b/js/nariya.js
@@ -263,12 +263,12 @@ function na_good(bo_table, wr_id, act, id, opt) {
 			na_alert(data.error, function(){}, 2500);
 			return false;
 		} else if(data.success) {
-			na_alert(data.success, function(){
+			//na_alert(data.success, function(){	추천후 Alert 제거
 				$("#"+id).text(number_format(String(data.count)));
 				if($("."+id+'_cnt').length) {
 					$("."+id+'_cnt').text(number_format(String(data.count)));
 				}				
-			}, 2500);
+			//}, 2500);
 		}
 	}, "json");
 }

--- a/layout/basic/widget/wr-list/widget.php
+++ b/layout/basic/widget/wr-list/widget.php
@@ -79,7 +79,7 @@ for ($i=0; $i < $list_cnt; $i++) {
 	<li class="list-group-item<?php echo ($row['is_notice']) ? $wr_notice : ''; ?>" onclick="location.href='<?php echo $row['href'] ?>'" style="cursor:pointer">
 		<div class="d-flex align-items-center gap-1">
 			<div class="text-truncate">
-				<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+				<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> onclick="return false">	<!-- 게시글 제목 텍스트 부분 클릭시 서버요청 2번 하는 버그 수정 -->
 					<?php echo $wr_head ?>
 					<?php echo $row['subject'] ?>
 				</a>

--- a/skin/board/basic/list/list/list.skin.php
+++ b/skin/board/basic/list/list/list.skin.php
@@ -111,7 +111,7 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 					<div class="flex-grow-1">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
 							<div>
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> onclick="return false">		<!-- 게시글 제목 텍스트 부분 클릭시 서버요청 2번 하는 버그 수정 -->
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>


### PR DESCRIPTION
https://discord.com/channels/1223276360060108851/1226557123782250536
해당 이슈이며 게시글 리스트에서 제목 부분을 클릭하면 a태그와 onclick이벤트가 중복되어 페이지 요청이 2번 날아갑니다
서버부하가 더 발생할 수 있어 수정 필요해보입니다

추후 개선 가능성:
onclick이벤트 방식보다는 a태그를 텍스트만이 아닌 li상위로 올려서 전체영역에 링크가 걸리게 하는게 더 나은 방향이라고 봅니다
다만 이렇게 하면 트리구조가 바껴서 css수정까지 필요한 부분이 확인되어 추후 반영하는 것이 바람직해보입니다.