### PR TITLE
chore: 소모임 메뉴의 여백 조정

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -499,21 +499,6 @@ a:hover {
   background-color: rgba(189, 197, 209, 0.2);
 }
 
-.na-menu .nav-vertical.nav-pills .nav-collapse {
-  position: relative;
-  padding-left: 1.9375rem;
-}
-
-.na-menu .nav-vertical.nav-pills .nav-collapse::before {
-  position: absolute;
-  top: 0;
-  left: 1.3125rem;
-  width: 0.125rem;
-  height: calc(100% - 0.25rem);
-  content: '';
-  background-color: rgba(231, 234, 243, 0.7);
-}
-
 .na-menu .nav-vertical.nav-pills .nav-link.dropdown-toggle {
   display: -ms-flexbox;
   display: flex;
@@ -587,7 +572,7 @@ a:hover {
   align-items: center;
   flex: 0 0 33.33%;
   margin: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 0.5rem !important;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
![image](https://github.com/damoang/theme/assets/45934/65d3c203-be56-4a4c-b312-f81fdc0518f2)

제 의도와 달리 desktop 에서 말줄임이 많이 나와 조금 더 많은 글자가 보이게 수정을 좀 했습니다. 위 캡쳐가 결과입니다.