### PR TITLE
애플계열 기기에서 웹폰트 쓰지 않도록 수정

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -1,10 +1,10 @@
 @charset "UTF-8";
 
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500&family=Roboto:wght@300;400;500&display=swap');
+/* @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500&family=Roboto:wght@300;400;500&display=swap'); */
 
 root,
 [data-bs-theme='light'] {
-  --bs-body-font-family: 'Roboto', 'Noto Sans KR', "Malgun Gothic", 맑은고딕, sans-serif;
+  --bs-body-font-family: 'Roboto', 'Noto Sans KR', "Malgun Gothic", "맑은 고딕", "Helvetica", "Apple SD 산돌고딕 Neo", "Apple SD Gothic Neo", sans-serif;
   --bs-link-color: var(--bs-body-color);
   --bs-link-color-rgb: var(--bs-body-color-rgb);
   --na-bar-color: rgba(125, 125, 125, 0.5);
@@ -22,7 +22,7 @@ root,
 }
 
 [data-bs-theme='dark'] {
-  --bs-body-font-family: 'Roboto', 'Noto Sans KR', "Malgun Gothic", 맑은고딕, sans-serif;
+  --bs-body-font-family: 'Roboto', 'Noto Sans KR', "Malgun Gothic", "맑은 고딕", "Helvetica", "Apple SD 산돌고딕 Neo", "Apple SD Gothic Neo", sans-serif;
   --bs-link-color: var(--bs-body-color);
   --bs-link-color-rgb: var(--bs-body-color-rgb);
   --na-bar-color: rgba(125, 125, 125, 0.5);
@@ -545,10 +545,10 @@ a:hover {
 /*style.css 파일에서 .site-wrap 클래스에 overflow-y:scroll 추가*/
 
 /*호랑이2 님 요청사항 : 스크롤시 깜빡임 방지*/
-.site-wrap {
+/* .site-wrap {
   background: var(--na-footer-bg);
   overflow-y: scroll;
-}
+} */
 
 
 .nav-vertical.nav-pills .nav-collapse {

--- a/layout/basic/head.sub.php
+++ b/layout/basic/head.sub.php
@@ -43,6 +43,10 @@ add_stylesheet('<link rel="stylesheet" href="'.LAYOUT_URL.'/css/style.css">', 0)
 add_stylesheet('<link rel="stylesheet" href="'.G5_THEME_URL.'/css/bootstrap-icons.min.css">', 0);
 add_stylesheet('<link rel="stylesheet" href="'.G5_JS_URL.'/font-awesome/css/font-awesome.min.css">', 0);
 add_stylesheet('<link rel="canonical" href="'.$pset['href'].'">', 100);
+$agent = $_SERVER["HTTP_USER_AGENT"];
+if (!preg_match('/macintosh|mac os x/i', $agent)) {
+    add_stylesheet('<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500&family=Roboto:wght@300;400;500&display=swap">',0);
+}
 ?>
 
 <script>


### PR DESCRIPTION
여러차례 최적화 하고 테스트 해왔는데
애플계열 기기에서는 웹폰트 렌더링이 성능이 너무 안나오네요

특히 아이폰 크롬 때문에라도
기기에 따라 웹폰트 적용을 제외하는 것이 좋을것 같습니다

이 커밋을 적용하면 윈도/안드로이드 계열은 동일하게 유지되고
애플계열은 산돌고딕으로 나옵니다
같은 고딕계열이라 레이아웃 상 문제는 없어보입니다.