### PR TITLE
본문과 목록 사이에 목록으로 이동 버튼 추가

### DIFF
--- a/skin/board/basic/view/basic/view.skin.php
+++ b/skin/board/basic/view/basic/view.skin.php
@@ -456,6 +456,12 @@ document.getElementById('moveToTureRoomBtn').addEventListener('click', function(
 			</a>	
 		</div>
 		<?php } ?>
+		<div>
+			<a href="/<?php echo $bo_table ?>" class="btn btn-basic btn-sm" title="목록보기">
+				<i class="bi bi-list-ul"></i>
+				<span class="d-none d-sm-inline-block">목록</span>
+			</a>
+		</div>
 		<?php echo $link_buttons; // 버튼 출력 ?>
 	</div>
 </article>


### PR DESCRIPTION
![IMG_381](https://github.com/damoang/theme/assets/60917154/0ccebd04-68ab-4fcc-9497-cbb9f692d617)

본문 페이지에서 본문과 목록 사이에 목록으로 이동 버튼을 추가합니다.