### PR TITLE
다크 테마에서 읽은글 css 적용

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -19,6 +19,7 @@ root,
   --na-title-color: var(--bs-body-color);
   --na-title-bg: var(--bs-tertiary-bg);
   --na-footer-bg: var(--bs-tertiary-bg);
+  --na-sub-visited-color: #adb5bd;
 }
 
 [data-bs-theme='dark'] {
@@ -37,6 +38,7 @@ root,
   --na-title-color: var(--bs-body-color);
   --na-title-bg: var(--bs-tertiary-bg);
   --na-footer-bg: var(--bs-tertiary-bg);
+  --na-sub-visited-color: #6c757d;
 }
 
 /* 기본 공통 */
@@ -538,7 +540,7 @@ a:hover {
 }
 /* 유저이름을 제외하고 제목에만 읽은 글(visited) 효과를 부여 */
 .list-group-item a:not(.wr-name a):visited {
-  color: var(--bs-gray-500);
+  color: var(--na-sub-visited-color);
   text-decoration: none;
 }
 


### PR DESCRIPTION
- 기능으로 추가된 읽은글 표시에 대해서 다크 테마에서 색깔 구분이 명확했으면 좋겠다는 의견이 많이 있어서, 추가 반영을 하였습니다.
- 기존 light/dark 테마일때 공통적용한 color를 각 테마에 어울리는 색상으로 개별 적용.