### PR TITLE
목록 마우스 오버시 썸네일 500ms 시간 차  추가

### DIFF
--- a/js/nariya.js
+++ b/js/nariya.js
@@ -619,15 +619,31 @@ $(function(){
 		$('[data-bs-toggle="tooltip"]').tooltip('disable');
 
 	} else {
-		$(document).on("mouseover", '[data-bs-toggle="popover-img"]', function () {
-			var e = $(this);
-			e.off('hover');
-			e.popover({
-			  html: true,
-			  trigger: 'hover',
-			  placement: 'left',
-			  content: function () { return '<div class="rounded overflow-hidden" style="max-height:200px;"><img src="' + e.data('img') + '" class="w-100"/></div>'; }
-			}).popover('show');
+		let debounceTimeout;
+		function debounce(func, delay) {
+			clearTimeout(debounceTimeout);
+			debounceTimeout = setTimeout(func, delay);
+		}
+
+		$('[data-bs-toggle="popover-img"]:not([data-popover-initialized])').hover(function () {
+
+			var $element = $(this);
+			debounce(function() {
+				$element.attr('data-popover-initialized', true); // Mark as initialized to avoid duplicate binding
+				$element.popover({
+					html: true,
+					trigger: 'hover',
+					placement: 'left',
+					content: function () {
+						return '<div class="rounded overflow-hidden" style="max-height:200px;">' +
+							'<img src="' + $element.data('img') + '" class="w-100"/></div>';
+					}
+				}).popover('show');
+			}, 500); //썸네일 뜨는 시간 ms 단위
+		});
+
+		$(document).on("mouseleave", '[data-bs-toggle="popover-img"]', function () {
+			clearTimeout(debounceTimeout);
 		});
 	}
 

--- a/js/nariya.js
+++ b/js/nariya.js
@@ -629,7 +629,7 @@ $(function(){
 
 			var $element = $(this);
 			debounce(function() {
-				$element.attr('data-popover-initialized', true); // Mark as initialized to avoid duplicate binding
+				$element.attr('data-popover-initialized', true);
 				$element.popover({
 					html: true,
 					trigger: 'hover',
@@ -639,7 +639,7 @@ $(function(){
 							'<img src="' + $element.data('img') + '" class="w-100"/></div>';
 					}
 				}).popover('show');
-			}, 500); //썸네일 뜨는 시간 ms 단위
+			}, 500); //썸네일 뜨는 시간 ms
 		});
 
 		$(document).on("mouseleave", '[data-bs-toggle="popover-img"]', function () {


### PR DESCRIPTION
현재 다모앙은 목록에서 마우스가 지나가기만해도 썸네일을 표시하기 위해 이미지를 다운받습니다.

유저는 그저 마우스만 슥 지나가도 썸네일이 떠서 깜빡거릴뿐더러 트래픽이 소모됩니다.
트래픽 소모를 줄이기 위해 500ms 뒤에도 마우스가 그 자리에 있으면 썸네일이 표시됩니다.
