### PR TITLE
fix: IP를 보여주는 툴팁이 메모 popover를 가리는 문제 수정

### DIFF
--- a/skin/board/basic/comment/true/comment.skin.php
+++ b/skin/board/basic/comment/true/comment.skin.php
@@ -93,7 +93,7 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
 						<?php if ($comment_depth) { ?><span class="visually-hidden">댓글의</span><?php } ?> 댓글
 					</h3>
 					<div class="d-flex align-items-center border-top <?php echo $by_writer ?> py-1 px-3 small">
-						<div class="me-2"<?php echo $is_ip_view ? ' data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="'.$list[$i]['ip'].'"' : ''; ?>>
+						<div class="me-2">
 							<?php if ($comment_depth) { ?>
 								<i class="bi bi-arrow-return-right"></i>
 								<span class="visually-hidden">대댓글</span>

--- a/skin/board/basic/view/true/view.skin.php
+++ b/skin/board/basic/view/true/view.skin.php
@@ -19,7 +19,7 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/style.css">', 0
 	<section id="bo_v_info">
         <h3 class="visually-hidden">페이지 정보</h3>
 		<div class="d-flex justify-content-end align-items-center line-top border-bottom bg-body-tertiary py-2 px-3 small">
-			<div class="me-auto"<?php echo $is_ip_view ? ' data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="'.$ip.'"' : ''; ?>>
+			<div class="me-auto">
 				<span class="visually-hidden">작성자</span>
 				<?php 
 					$wr_name = ($view['mb_id']) ? str_replace('sv_member', 'sv_member text-truncate', $view['name']) : str_replace('sv_guest', 'sv_guest text-truncate', $view['name']); 

--- a/skin/board/free/comment/basic/comment.skin.php
+++ b/skin/board/free/comment/basic/comment.skin.php
@@ -111,7 +111,7 @@ if(!$is_ajax)
                             <?php if ($comment_depth) { ?><span class="visually-hidden">댓글의</span><?php } ?> 댓글
                         </h3>
                         <div class="d-flex align-items-center border-top <?php echo $by_writer ?> py-1 px-3 small">
-                            <div class="me-2"<?php echo $is_ip_view ? ' data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="'.$list[$i]['ip'].'"' : ''; ?>>
+                            <div class="me-2">
                                 <?php if ($comment_depth) { ?>
                                     <i class="bi bi-arrow-return-right"></i>
                                     <span class="visually-hidden">대댓글</span>

--- a/skin/board/free/comment/true/comment.skin.php
+++ b/skin/board/free/comment/true/comment.skin.php
@@ -93,7 +93,7 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
 						<?php if ($comment_depth) { ?><span class="visually-hidden">댓글의</span><?php } ?> 댓글
 					</h3>
 					<div class="d-flex align-items-center border-top <?php echo $by_writer ?> py-1 px-3 small">
-						<div class="me-2"<?php echo $is_ip_view ? ' data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="'.$list[$i]['ip'].'"' : ''; ?>>
+						<div class="me-2">
 							<?php if ($comment_depth) { ?>
 								<i class="bi bi-arrow-return-right"></i>
 								<span class="visually-hidden">대댓글</span>


### PR DESCRIPTION
IP는 이미 닉네임 옆에 보여지고 있으므로 IP를 중복으로 표시하는 툴팁 제거.