### PR TITLE
fix: 위젯 설정에서 폼을 초기화하는 문제 고침

### DIFF
--- a/app/widget.form.php
+++ b/app/widget.form.php
@@ -47,10 +47,10 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
 <div class="sticky-bottom p-3 bg-body border-top">
 	<div class="row justify-content-center g-3">
 		<div class="col col-sm-4 col-md-3 col-lgx-2">
-			<button type="submit" class="btn btn-danger w-100" onclick="document.pressed='reset'">초기화</button>
+			<button type="submit" onclick="document.pressed='save'" class="btn btn-primary w-100">저장하기</button>
 		</div>
-		<div class="col col-sm-4 col-md-3 col-lgx-2">
-			<button type="submit" class="btn btn-primary w-100">저장하기</button>
+		<div class="col col-sm-4 col-md-3 col-lgx-2 ms-5">
+			<button type="submit" class="btn btn-sm btn-outline-danger" onclick="document.pressed='reset'">초기화</button>
 		</div>
 	</div>
 </div>
@@ -63,6 +63,8 @@ function fsetup_submit(f) {
 			f.submit();
 		});
 		return false;
+	}  else {
+		f.freset.value = null;
 	}
 }
 </script>


### PR DESCRIPTION
위젯 설정 시 '초기화' 버튼이 실수로 동작하여 설정이 초기화될 수 있는 문제 방지

나리야 위젯설정 기능에서 "초기화" 버튼이 먼저 폼을 전송하도록 구현되어있어서 실수로 위젯 설정이 초기화 될 수 있는 문제.