### PR TITLE
feat: 메뉴에 항목마다 이름을 가진 CSS class 추가

### DIFF
--- a/layout/basic/component/menu.offcanvas.php
+++ b/layout/basic/component/menu.offcanvas.php
@@ -60,11 +60,16 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                             $menuItem['icon'] = $menuItem['icon'] ?? 'bi-clipboard';
                             $hasSub = !empty($menuItem['items']) && is_array($menuItem['items']);
                             $menuItem['page_id'] = $menuItem['page_id'] ?? '';
-
                             if (!$menuItem['page_id']) {
                                 if (preg_match('/\/([a-zA-Z0-9]+)$/i', $menuItem['url'], $matches)) {
                                     $menuItem['page_id'] = G5_BBS_DIR . '-board-' . $matches[1];
                                 }
+                            }
+                            $menuItem['shortcut'] = $menuItem['shortcut'] ?? '';
+                            $menuItem['icon'] = $menuItem['icon'] ?? '';
+                            $menuItem['class'] = $menuItem['class'] ?? '';
+                            if (!$menuItem['class'] && $menuItem['page_id']) {
+                                $menuItem['class'] = 'da--menu-' . $menuItem['page_id'];
                             }
 
                             if ($hasSub) {
@@ -103,7 +108,7 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                         <?php } ?>
                     <?php } // endforeach $siteMenus ?>
 
-                    <div class="nav-item">
+                    <div class="nav-item da-menu--device-mode">
                         <a class="nav-link" href="<?php echo get_device_change_url() ?>" data-placement="left">
                             <i class="<?php echo (G5_IS_MOBILE) ? 'bi-pc-display' : 'bi-tablet'; ?> nav-icon"></i>
                             <span class="nav-link-title"><?php echo (G5_IS_MOBILE) ? 'PC' : '모바일'; ?> 버전</span>

--- a/layout/basic/component/sidebar.php
+++ b/layout/basic/component/sidebar.php
@@ -55,6 +55,17 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                         $menuItem['icon'] = $menuItem['icon'] ?? 'bi-clipboard';
                         $hasSub = !empty($menuItem['items']) && is_array($menuItem['items']);
                         $menuItem['page_id'] = $menuItem['page_id'] ?? '';
+                        if (!$menuItem['page_id']) {
+                            if (preg_match('/\/([a-zA-Z0-9]+)$/i', $menuItem['url'], $matches)) {
+                                $menuItem['page_id'] = G5_BBS_DIR . '-board-' . $matches[1];
+                            }
+                        }
+                        $menuItem['shortcut'] = $menuItem['shortcut'] ?? '';
+                        $menuItem['icon'] = $menuItem['icon'] ?? '';
+                        $menuItem['class'] = $menuItem['class'] ?? '';
+                        if (!$menuItem['class'] && $menuItem['page_id']) {
+                            $menuItem['class'] = 'da--menu-' . $menuItem['page_id'];
+                        }
 
                         if (!$menuItem['page_id']) {
                             if (preg_match('/\/([a-zA-Z0-9]+)$/i', $menuItem['url'], $matches)) {
@@ -70,7 +81,7 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                             $subMenus = $menuItem['items'];
                         }
                         ?>
-                        <div class="nav-item">
+                        <div class="nav-item da-menu--<?= $menuItem['page_id'] ?>">
                             <a
                                     class="nav-link <?= ($menuItem['page_id'] === $page_id) ? 'active' : ''; ?><?= ($hasSub) ? 'dropdown-toggle collapsed collapsed' : '' ?>"
                                     href="<?= $menuItem['url'] ?>"
@@ -98,7 +109,7 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                     <?php } ?>
                 <?php } // endforeach $siteMenus ?>
 
-                <div class="nav-item">
+                <div class="nav-item da-menu--device-mode">
                     <a class="nav-link" href="<?php echo get_device_change_url() ?>" data-placement="left">
                         <i class="<?php echo (G5_IS_MOBILE) ? 'bi-pc-display' : 'bi-tablet'; ?> nav-icon"></i>
                         <span class="nav-link-title"><?php echo (G5_IS_MOBILE) ? 'PC' : '모바일'; ?> 버전</span>

--- a/layout/basic/js/customui.js
+++ b/layout/basic/js/customui.js
@@ -530,7 +530,7 @@
             }
         }
 
-        links = $("#sidebar-site-menu a.nav-link.dropdown-toggle").parent().find("div > a");
+        links = $("#sidebar-site-menu .da-menu--bbs-group-group").find("div > a");
         for (var i = 0; i < links.length; i++) {
             var temp_link_obj = $(links[i]);
             var temp_name = temp_link_obj.html().trim();


### PR DESCRIPTION
메뉴 항목마다 링크 대상에 따른 이름을 가진 CSS Class 를 추가 함.
`da-menu--`로 시작하는 클래스명으로 지정됨.
단축키 설정 등에서 활용할 수 있음.

- PHP 8 호환성 문제 수정