### PR TITLE
<a> 태그 중복 제거 코드 추가

### DIFF
--- a/skin/board/basic/view/basic/view.skin.php
+++ b/skin/board/basic/view/basic/view.skin.php
@@ -231,7 +231,18 @@ add_stylesheet('<link rel="stylesheet" href="' . $board_skin_url . '/style.css">
             }
             ?>
             <div id="bo_v_con" class="<?php echo $is_convert ?>">
-                <?php echo get_view_thumbnail(na_view($view)); // 글내용 출력 ?>
+                <?php
+                /**
+                 * 이미지에 링크 삽입 시 이미지 크게보기 팝업 링크와 중복 삽입되므로
+                 * 중첩 <a> 태그를 치환합니다.
+                 */
+
+                $view_replaced = preg_replace(
+                    '/<a[\s]+([^>]+)><a[\s]+([^>]+)>((?:.(?!\<\/a\>))*.)<\/a><\/a>/m',
+                    '<a $1>$3</a>', get_view_thumbnail(na_view($view)));
+
+                echo $view_replaced; // 글내용 출력
+                ?>
             </div>
             <?php // if ($is_signature) { // 서명 ?>
 


### PR DESCRIPTION
관련 이슈: https://discord.com/channels/1223276360060108851/1235944498090082334

이미지에 삽입한 링크와 이미지 크게보기 링크가 중첩으로 달리는 문제가 있으므로

위와 같은 상황에서 이미지 크게보기 링크를 제거합니다.