### PR TITLE
nariya.js 버전 태그 변경

### DIFF
--- a/layout/basic/_head.sub.php
+++ b/layout/basic/_head.sub.php
@@ -227,7 +227,7 @@ $one_cols = array(
         <script src="<?php echo G5_THEME_URL ?>/js/wrest.js?ver=<?php echo G5_JS_VER; ?>"></script>
         <script src="<?php echo G5_THEME_URL ?>/js/bootstrap.bundle.min.js?ver=<?php echo G5_JS_VER; ?>"></script>
         <script src="<?php echo G5_THEME_URL ?>/js/clipboard.min.js"></script>
-        <script src="<?php echo G5_THEME_URL ?>/js/nariya.js?ver=<?php echo G5_JS_VER; ?>"></script>
+        <script src="<?php echo G5_THEME_URL ?>/js/nariya.js?ver=2404281"></script>
         <script src="<?php echo LAYOUT_URL ?>/js/darkmode.js?ver=<?php echo G5_JS_VER; ?>"
                 data-cfasync="false"></script>
         <?php

--- a/layout/basic/head.sub.php
+++ b/layout/basic/head.sub.php
@@ -160,7 +160,7 @@ $one_cols = array(
   <script src="<?php echo G5_THEME_URL ?>/js/wrest.js?ver=<?php echo G5_JS_VER; ?>"></script>
   <script src="<?php echo G5_THEME_URL ?>/js/bootstrap.bundle.min.js?ver=<?php echo G5_JS_VER; ?>"></script>
   <script src="<?php echo G5_THEME_URL ?>/js/clipboard.min.js"></script>
-  <script src="<?php echo G5_THEME_URL ?>/js/nariya.js?ver=<?php echo G5_JS_VER; ?>"></script>
+  <script src="<?php echo G5_THEME_URL ?>/js/nariya.js?ver=2404281"></script>
   <script src="<?php echo LAYOUT_URL ?>/js/darkmode.js?ver=<?php echo G5_JS_VER; ?>" data-cfasync="false"></script>
   <script src="<?php echo LAYOUT_URL ?>/js/customui.js?ver=<?php echo G5_JS_VER; ?>" data-cfasync="false"></script>
   <script src="<?php echo LAYOUT_URL ?>/js/custom_features.js?ver=<?php echo G5_JS_VER; ?>" data-cfasync="false">


### PR DESCRIPTION
js_ver 태그는 밖에있고 관리하기도 신경쓰이고
버전태그는 파일 변경할때 같이 바꿔주는게 좋지 않을까요?

js/css 캐시가 1년이라 당장바뀌어야합니다