### PR TITLE
fix(customui): #141 미리보기 끔 설정 사용 시 `popover` 표시 문제 고침

### DIFF
--- a/js/nariya.js
+++ b/js/nariya.js
@@ -628,6 +628,9 @@ $(function(){
 		$('[data-bs-toggle="popover-img"]:not([data-popover-initialized])').hover(function () {
 
 			var $element = $(this);
+			if ($element.data('bs-popover-disabled')) {
+				return;
+			}
 			debounce(function() {
 				$element.attr('data-popover-initialized', true);
 				$element.popover({

--- a/layout/basic/js/customui.js
+++ b/layout/basic/js/customui.js
@@ -27,7 +27,9 @@
 
                 //미리보기창 끄기
                 if (ui_obj.img_preview != null && ui_obj.img_preview) {
-                    ui_custom_style += "div.popover.bs-popover-auto.fade.show {display: none !important;}\n";
+                    $(function () {
+                        $('[data-bs-toggle="popover-img"]').data('bs-popover-disabled', 'true');
+                    })();
                 }
 
                 //root style 글씨체 및 크기


### PR DESCRIPTION
미리보기 끔 설정으로 인해 bootstrap의 `popover` 패널이 표시되지 않는 문제 고침.

`popover` 패널을 감추는 대신 미리보기 항목에 `bs-popover-disabled` 속성을 추가하여 미리보기 기능의 비활성화 상태를 사용함