### PR TITLE
fix: 잘못 지정된 테마 컬러 제거

### DIFF
--- a/img/favicon/browserconfig.xml
+++ b/img/favicon/browserconfig.xml
@@ -3,7 +3,6 @@
     <msapplication>
         <tile>
             <square150x150logo src="/theme/damoang/img/favicon/mstile-150x150.png"/>
-            <TileColor>#ffffff</TileColor>
         </tile>
     </msapplication>
 </browserconfig>

--- a/img/favicon/site.webmanifest
+++ b/img/favicon/site.webmanifest
@@ -13,7 +13,6 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
     "background_color": "#ffffff",
     "display": "standalone"
 }

--- a/layout/basic/head.sub.php
+++ b/layout/basic/head.sub.php
@@ -58,7 +58,6 @@ $one_cols = array(
   <link rel="manifest" href="<?= G5_THEME_URL ?>/img/favicon/site.webmanifest">
   <link rel="shortcut icon" href="<?= G5_THEME_URL ?>/img/favicon/favicon.ico">
   <meta name="msapplication-config" content="<?= G5_THEME_URL ?>/img/favicon/browserconfig.xml">
-  <meta name="theme-color" content="#ffffff">
 
   <script>
   (function() {


### PR DESCRIPTION
favicon 추가 시 임시로 설정된 테머 컬러를 제거.

https://damoang.net/bug/2985
![thumb-16626e71e2e1aad410c4d2feb654fbe4_bkTGrMhA_43204954fd1283a7df4b90b89ea5425022d20dc7_835x256](https://github.com/damoang/theme/assets/112419763/61f8a6d6-b09b-4d7b-a6e2-1f057293f51f)
