### PR TITLE
feat: 공지사항 감추기 버튼을 공지사항이 있을 때만 표시하도록 변경

### DIFF
--- a/skin/board/basic/category/basic/category.skin.php
+++ b/skin/board/basic/category/basic/category.skin.php
@@ -20,6 +20,11 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
 		?>
 		<b><?php echo number_format((int)$total_count) ?></b> / <?php echo $page ?> 페이지
 	</div>
+
+	<?php
+	// 공지사항 감추기
+	if ($notice_count) {
+	?>
 	<div class="ms-auto order-1 pe-1">
 		<a href="#" id="hide_notice" class="text-body-tertiary">
 			<span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="공지사항">
@@ -28,6 +33,7 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
 			</span>
 		</a>
 	</div>
+	<?php } ?>
 
 	<div class="order-3 pe-1">
 		<a href="#boardSearch" data-bs-toggle="collapse" data-bs-target="#boardSearch" aria-expanded="false" aria-controls="boardSearch" class="text-body-tertiary">

--- a/skin/board/free/category/basic/category.skin.php
+++ b/skin/board/free/category/basic/category.skin.php
@@ -20,6 +20,11 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
 		?>
 		<b><?php echo number_format((int)$total_count) ?></b> / <?php echo $page ?> 페이지
 	</div>
+
+	<?php
+	// 공지사항 감추기
+	if ($notice_count) {
+	?>
 	<div class="ms-auto order-1 pe-1">
 		<a href="#" id="hide_notice" class="text-body-tertiary">
 			<span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="공지사항">
@@ -28,6 +33,7 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
 			</span>
 		</a>
 	</div>
+	<?php } ?>
 
 	<div class="order-3 pe-1">
 		<a href="#boardSearch" data-bs-toggle="collapse" data-bs-target="#boardSearch" aria-expanded="false" aria-controls="boardSearch" class="text-body-tertiary">


### PR DESCRIPTION
공지사항이 없을 때도 아이콘이 표시되어 동작하지 않는 것처럼 보이거나 의도하지 않게 공지사항 감추기 상태가 변경될 수 있는 사용성 문제를 개선.




디스코드 이슈: https://discord.com/channels/1223276360060108851/1240384078767849613