### PR TITLE
제목영역 레이아웃 정리 및 툴팁 적용

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -648,3 +648,29 @@ a.da-link-block:before {
   top: 0;
   bottom: 0;
 }
+
+.list-group-item {
+  .subject-ellipsis {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .badge {
+    position: relative;
+    top: 3px;
+  }
+  .d-inline-flex {
+    .na-icon,
+    .float-end,
+    .count-plus
+     {
+      flex-shrink: 0;
+      top: 6px;
+      margin-left: 3px;
+    }
+    .float-end,
+    .count-plus {
+      margin-right: 3px;
+    }
+  }
+}

--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -655,7 +655,7 @@ a.da-link-block:before {
     overflow: hidden;
     white-space: nowrap;
   }
-  .badge {
+  .badge.text-body-tertiary {
     position: relative;
     top: 3px;
   }

--- a/skin/board/basic/list/list-sm/list.skin.php
+++ b/skin/board/basic/list/list-sm/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1 small">
+					<div class="flex-grow-1 small overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>

--- a/skin/board/basic/list/list/list.skin.php
+++ b/skin/board/basic/list/list/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block">
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>

--- a/skin/board/basic/list/list_admin/list.skin.php
+++ b/skin/board/basic/list/list_admin/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>

--- a/skin/board/basic/list/list_trueroom/list.skin.php
+++ b/skin/board/basic/list/list_trueroom/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>

--- a/skin/board/free/list/list-sm/list.skin.php
+++ b/skin/board/free/list/list-sm/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1 small">
+					<div class="flex-grow-1 small overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>

--- a/skin/board/free/list/list/list.skin.php
+++ b/skin/board/free/list/list/list.skin.php
@@ -113,10 +113,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                         </div>
 
                     <?php } ?>
-                    <div class="flex-grow-1">
-                        <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="flex-fill">
-                                <a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block <?php if ($list[$i]['wr_1'] == '1') { ?> da-member-only <?php } ?> ">
+					<div class="flex-grow-1 overflow-hidden">
+						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block <?php if ($list[$i]['wr_1'] == '1') { ?> da-member-only <?php } ?> subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
                                     <?php if($row['icon_reply']) { ?>
                                         <i class="bi bi-arrow-return-right"></i>
                                         <span class="visually-hidden">답변</span>

--- a/skin/board/free/list/list_admin/list.skin.php
+++ b/skin/board/free/list/list_admin/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>

--- a/skin/board/free/list/list_trueroom/list.skin.php
+++ b/skin/board/free/list/list_trueroom/list.skin.php
@@ -107,10 +107,10 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="flex-fill">
-								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?>>
+							<div class="d-inline-flex flex-fill overflow-hidden">
+								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>
 										<span class="visually-hidden">답변</span>


### PR DESCRIPTION
리스트에서 제목 길이가 길어지더라도 한줄로 정리되어 표시됩니다
마우스 오버하면 툴팁으로 전체 제목이 표시됩니다

관리자 모드에서 제목길이(모바일 제목 길이 포함)를 길게 수정해주셔야합니다. 100자이상으로 놔도 됩니다.

(전체 제목인 wr_subject를 쓸까 했으나 그누보드에서 뭔가 제목에 대해 처리하는 로직이 있는걸로 보입니다. 그러므로 subject 를 그대로 쓰면서 관리자모드에서 수정하는 것이 안전)