### PR TITLE
제목 말줄임 표시 로직 파이어폭스에서 적용안되는 문제 해결

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -649,32 +649,34 @@ a.da-link-block:before {
   bottom: 0;
 }
 
-.list-group-item {
-  .subject-ellipsis {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
-  .badge.text-body-tertiary {
-    position: relative;
-    top: 3px;
-  }
-  .d-inline-flex {
-    .na-icon,
-    .float-end,
-    .count-plus
-    {
-      flex-shrink: 0;
-      top: 6px;
-      margin-left: 3px;
-    }
-    .float-end,
-    .count-plus {
-      margin-right: 3px;
-    }
-  }
+.list-group-item .subject-ellipsis {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.list-group-item .badge.text-body-tertiary {
+  position: relative;
+  top: 3px;
 }
 
-.overflow-x-clip {
-  overflow-x: clip;
+.list-group-item .d-inline-flex .na-icon,
+.list-group-item .d-inline-flex .float-end,
+.list-group-item .d-inline-flex .count-plus {
+  flex-shrink: 0;
+  top: 8px;
+  margin-left: 3px;
+}
+.list-group-item .d-inline-flex .float-end,
+.list-group-item .d-inline-flex .count-plus {
+  margin-right: 3px;
+}
+.list-group-item .wr-name .sv_wrap {
+  position: inherit;
+}
+.list-group-item .wr-name .sv_wrap a.sv_member {
+  position: relative;
+}
+.list-group-item .wr-name .sv_wrap .sv.sv_on{
+  left: unset;
+  top: unset;
 }

--- a/skin/board/basic/list/list-sm/list.skin.php
+++ b/skin/board/basic/list/list-sm/list.skin.php
@@ -104,9 +104,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                             </label>
                         </div>
                     <?php } ?>
-                    <div class="flex-grow-1 small overflow-x-clip" style="overflow-x:clip">
+                    <div class="flex-grow-1 small overflow-hidden">
                         <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+                            <div class="d-inline-flex flex-fill overflow-hidden">
                                 <?php
                                 // 회원만 보기
                                 echo $row['da_member_only'] ?? '';

--- a/skin/board/basic/list/list/list.skin.php
+++ b/skin/board/basic/list/list/list.skin.php
@@ -104,9 +104,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                             </label>
                         </div>
                     <?php } ?>
-                    <div class="flex-grow-1 overflow-x-clip" style="overflow-x:clip">
+                    <div class="flex-grow-1 overflow-hidden">
                         <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+                            <div class="d-inline-flex flex-fill overflow-hidden">
                                 <?php
                                 // 회원만 보기
                                 echo $row['da_member_only'] ?? '';

--- a/skin/board/basic/list/list_admin/list.skin.php
+++ b/skin/board/basic/list/list_admin/list.skin.php
@@ -104,9 +104,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                             </label>
                         </div>
                     <?php } ?>
-                    <div class="flex-grow-1 overflow-x-clip" style="overflow-x:clip">
+                    <div class="flex-grow-1 overflow-hidden">
                         <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+                            <div class="d-inline-flex flex-fill overflow-hidden">
                                 <?php
                                 // 회원만 보기
                                 echo $row['da_member_only'] ?? '';

--- a/skin/board/basic/list/list_trueroom/list.skin.php
+++ b/skin/board/basic/list/list_trueroom/list.skin.php
@@ -104,9 +104,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                             </label>
                         </div>
                     <?php } ?>
-                    <div class="flex-grow-1 overflow-x-clip" style="overflow-x:clip">
+                    <div class="flex-grow-1 overflow-hidden">
                         <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+                            <div class="d-inline-flex flex-fill overflow-hidden">
                                 <?php
                                 // 회원만 보기
                                 echo $row['da_member_only'] ?? '';

--- a/skin/board/free/list/list-sm/list.skin.php
+++ b/skin/board/free/list/list-sm/list.skin.php
@@ -107,9 +107,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1 small overflow-x-clip" style="overflow-x:clip">
+					<div class="flex-grow-1 small overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+							<div class="d-inline-flex flex-fill overflow-hidden">
 								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>

--- a/skin/board/free/list/list/list.skin.php
+++ b/skin/board/free/list/list/list.skin.php
@@ -113,9 +113,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                         </div>
 
                     <?php } ?>
-                    <div class="flex-grow-1 overflow-x-clip" style="overflow-x:clip">
+                    <div class="flex-grow-1 overflow-hidden">
                         <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+                            <div class="d-inline-flex flex-fill overflow-hidden">
                                 <?php
                                 // 회원만 보기
                                 echo ($list[$i]['wr_1'] == '1') ? '<em class="border rounded p-1" style="font-size: 0.75em; font-style: normal; flex-shrink:0; margin-right: 3px;">회원만</em>' : '';

--- a/skin/board/free/list/list_admin/list.skin.php
+++ b/skin/board/free/list/list_admin/list.skin.php
@@ -107,9 +107,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1 overflow-x-clip" style="overflow-x:clip">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+							<div class="d-inline-flex flex-fill overflow-hidden">
 								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>

--- a/skin/board/free/list/list_trueroom/list.skin.php
+++ b/skin/board/free/list/list_trueroom/list.skin.php
@@ -107,9 +107,9 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
 							</label>
 						</div>
 					<?php } ?>
-					<div class="flex-grow-1 overflow-x-clip" style="overflow-x:clip">
+					<div class="flex-grow-1 overflow-hidden">
 						<div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-							<div class="d-inline-flex flex-fill overflow-x-clip" style="overflow-x:clip">
+							<div class="d-inline-flex flex-fill overflow-hidden">
 								<a href="<?php echo $row['href'] ?>"<?php echo $img_popover ?> class="da-link-block subject-ellipsis" title="<?php echo $row['wr_subject']; ?>">
 									<?php if($row['icon_reply']) { ?>
 										<i class="bi bi-arrow-return-right"></i>


### PR DESCRIPTION
유저 사이드뷰 표시를 위해 overflow 처리 방식을 변경했었는데,
파이어폭스에서 정상적으로 표시되지 않는 리포트를 받아

overflow 처리방식은 hidden으로 원복하고,
사이드뷰 position방식을 변경하는 방식으로 다시 구현했습니다.