### PR TITLE
댓글 목록의 시인성 개선

### DIFF
--- a/skin/board/basic/comment/basic/comment.skin.php
+++ b/skin/board/basic/comment/basic/comment.skin.php
@@ -80,10 +80,13 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
         // 댓글목록
 
         $comment_cnt = count($list);
-        for ($i=0; $i<$comment_cnt; $i++) {
+        $wr_names = [];
+        for ($i = 0; $i < $comment_cnt; $i++) {
             $comment_id = $list[$i]['wr_id'];
             $comment_depth = strlen($list[$i]['wr_comment_reply']) * 1;
             $comment = $list[$i]['content'];
+
+            $wr_names[$list[$i]['wr_comment_reply']] = $list[$i]['wr_name'];
 
             // 이미지
             $comment = preg_replace("/\[\<a\s*href\=\"(http|https|ftp)\:\/\/([^[:space:]]+)\.(gif|png|jpg|jpeg|bmp|webp)\"\s*[^\>]*\>[^\s]*\<\/a\>\]/i", "<img src=\"$1://$2.$3\" alt=\"\">", $comment);
@@ -104,6 +107,7 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
 
             $comment_name = get_text($list[$i]['wr_name']);
             $by_writer = ($view['mb_id'] && $view['mb_id'] == $list[$i]['mb_id']) ? 'bg-body-secondary' : 'bg-body-tertiary';
+            $parent_wr_name = $wr_names[substr($list[$i]['wr_comment_reply'], 0, -1)];
 
         ?>
         <article id="c_<?php echo $comment_id ?>" <?php if ($comment_depth) { ?>style="margin-left:<?php echo $comment_depth ?>rem;"<?php } ?>>
@@ -138,6 +142,9 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
                 </header>
                 <div class="comment-content p-3">
                     <div class="<?php echo $is_convert ?>">
+                        <?php if ($comment_depth) { ?>
+                            <em class="da-commented-to"><strong>@<?= $parent_wr_name ?></strong>님에게 답글</em>
+                        <?php } ?>
                         <?php
                         $is_lock = false;
                         if (strstr($list[$i]['wr_option'], "secret")) {
@@ -660,3 +667,14 @@ if($is_ajax)
     });
     </script>
 <?php } ?>
+
+<style>
+    .da-commented-to {
+        display: block;
+        position: relative;
+        top: -0.5rem;
+        color: rgb(var(--bs-secondary-rgb));
+        font-size: 0.875em;
+        font-style: normal;
+    }
+</style>

--- a/skin/board/basic/comment/basic/comment.skin.php
+++ b/skin/board/basic/comment/basic/comment.skin.php
@@ -175,7 +175,7 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
                         ?>
                             <?php if ($list[$i]['is_reply']) { ?>
                                 <button type="button" class="btn btn-basic" onclick="comment_box('<?php echo $comment_id ?>','c','<?php echo $comment_name;?>');" class="btn btn-basic btn-sm" title="답글">
-                                    <i class="bi bi-arrow-return-right"></i>
+                                    <i class="bi bi-chat-dots"></i>
                                     답글
                                 </button>
                             <?php } ?>

--- a/skin/board/basic/comment/basic/comment.skin.php
+++ b/skin/board/basic/comment/basic/comment.skin.php
@@ -106,7 +106,7 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
             $is_comment_reply_edit = ($list[$i]['is_reply'] || $list[$i]['is_edit'] || $list[$i]['is_del']) ? 1 : 0;
 
             $comment_name = get_text($list[$i]['wr_name']);
-            $by_writer = ($view['mb_id'] && $view['mb_id'] == $list[$i]['mb_id']) ? 'bg-body-secondary' : 'bg-body-tertiary';
+            $by_writer = ($view['mb_id'] && $view['mb_id'] == $list[$i]['mb_id']) ? 'bg-secondary-subtle' : 'bg-body-tertiary';
             $parent_wr_name = $wr_names[substr($list[$i]['wr_comment_reply'], 0, -1)];
 
         ?>


### PR DESCRIPTION
다음과 같은 사항을 포함합니다.

- 대댓글에 답변 대상자의 닉네임 표시를 추가
  - `@작성자님에게 답변`
- 댓글들을 구분할 때 시선을 방해하는 중복된 아이콘을 변경
  - "답변" 버튼의 아이콘 변경
- 글 작성자의 댓글을 구분하던 배경색을 차이를 증가 시켜 구분하기 좀 더 쉽도록 개선

<img width="478" alt="스크린샷 2024-05-24 오후 11 29 57" src="https://github.com/damoang/theme/assets/112419763/7015edc3-0f1e-4361-8a9b-951a59cf9f0f">
