### PR TITLE
폰트사이즈/줄간격 조절시 게시글 목록 아이콘그룹, 카테고리,댓글수 라인 맞지 않는 문제 조치

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -658,13 +658,15 @@ a.da-link-block:before {
   position: relative;
   top: 3px;
 }
-
+.list-group-item .d-inline-flex {
+  align-items: center;
+}
 .list-group-item .d-inline-flex .na-icon,
 .list-group-item .d-inline-flex .float-end,
 .list-group-item .d-inline-flex .count-plus {
   flex-shrink: 0;
-  top: 8px;
   margin-left: 3px;
+  vertical-align: middle;
 }
 .list-group-item .d-inline-flex .float-end,
 .list-group-item .d-inline-flex .count-plus {

--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -656,7 +656,7 @@ a.da-link-block:before {
 }
 .list-group-item .badge.text-body-tertiary {
   position: relative;
-  top: 3px;
+  align-self: center;
 }
 
 .list-group-item .d-inline-flex .na-icon,

--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -658,15 +658,13 @@ a.da-link-block:before {
   position: relative;
   top: 3px;
 }
-.list-group-item .d-inline-flex {
-  align-items: center;
-}
+
 .list-group-item .d-inline-flex .na-icon,
 .list-group-item .d-inline-flex .float-end,
 .list-group-item .d-inline-flex .count-plus {
   flex-shrink: 0;
   margin-left: 3px;
-  vertical-align: middle;
+  align-self: center;
 }
 .list-group-item .d-inline-flex .float-end,
 .list-group-item .d-inline-flex .count-plus {

--- a/skin/board/basic/comment/basic/comment.skin.php
+++ b/skin/board/basic/comment/basic/comment.skin.php
@@ -192,10 +192,12 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
                                 </a>
                             <?php } ?>
                         <?php } ?>
+                            <?php if(!empty($is_member)) { // 로그인한 회원만 복사 가능 ?>
                             <button type="button" onclick="copy_comment_link('<?php echo $comment_id ?>');" class="btn btn-basic" title="복사">
                                 <i class="bi bi-copy"></i>
                                 <span class="d-none d-sm-inline-block">복사</span>
                             </button>
+                            <?php } ?>
                             <button type="button" onclick="na_singo('<?php echo $bo_table ?>', '<?php echo $list[$i]['wr_id'] ?>', '0', 'c_<?php echo $comment_id ?>');" class="btn btn-basic" title="신고">
                                 <i class="bi bi-eye-slash"></i>
                                 <span class="d-none d-sm-inline-block">신고</span>


### PR DESCRIPTION
### 리스트 라인 정렬

[증상]
폰트사이즈, 줄간격을 기본 설정보다 작게 조절하면
게시판 목록 제목 옆의 아이콘 그룹외 항목들이 줄간격이 틀어져 버립니다.

[조치]
style.css 파일내 해당 요소의 top 속성을 제거하고 중앙 정렬 속성을 추가하였습니다.

[개선 전]
![image](https://github.com/damoang/theme/assets/3017941/c3ec5829-9ec8-44bf-957c-6c03d9a8b6ca)

[개선 후]
![image](https://github.com/damoang/theme/assets/3017941/196db28b-2f17-443a-97f8-f4610615a9d2)

--------------

### 댓글복사 기능

[증상]
미 로그인시 댓글 복사 함수가 없다고 나오며 복사 안됨

[조치]
복사 버튼은 로그인한 회원에게만 노출하도록 수정
