### PR TITLE
사이드바 메뉴의 아이콘, 단축키 표시를 정렬

### DIFF
--- a/layout/basic/component/menu.offcanvas.php
+++ b/layout/basic/component/menu.offcanvas.php
@@ -80,13 +80,13 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                             ?>
                             <div class="nav-item">
                                 <a
-                                    class="nav-link <?= ($menuItem['page_id'] === $page_id) ? 'active' : ''; ?><?= ($hasSub) ? 'dropdown-toggle collapsed collapsed' : '' ?>"
+                                    class="nav-link <?= ($menuItem['page_id'] === $page_id) ? ' active ' : ''; ?><?= ($hasSub) ? ' dropdown-toggle collapsed collapsed ' : '' ?>"
                                     href="<?= $menuItem['url'] ?>"
                                     data-placement="left"
                                     <?= ($hasSub) ? 'role="button" data-bs-toggle="collapse" data-bs-target="#' . $menuToggleId . '" aria-expanded="false" aria-controls="' . $menuToggleId . '"' : '' ?>
                                 >
                                     <i class="<?= $menuItem['icon'] ?> nav-icon"></i>
-                                    <span class="nav-link-title" <?= ($hasSub) ? ' onclick="na_href(\'' . $menuUrlOrigin . '\', \'_self\');"' : '' ?>>
+                                    <span class="nav-link-title">
                                         <?php if ($menuItem['shortcut']) { ?>
                                             <span class="badge text-bg-secondary"><?= $menuItem['shortcut'] ?></span>
                                         <?php } ?>

--- a/layout/basic/component/menu.offcanvas.php
+++ b/layout/basic/component/menu.offcanvas.php
@@ -85,10 +85,10 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                                     data-placement="left"
                                     <?= ($hasSub) ? 'role="button" data-bs-toggle="collapse" data-bs-target="#' . $menuToggleId . '" aria-expanded="false" aria-controls="' . $menuToggleId . '"' : '' ?>
                                 >
-                                    <i class="<?= $menuItem['icon'] ?> nav-icon"></i>
-                                    <span class="nav-link-title">
+                                    <span class="d-flex align-items-center gap-2 nav-link-title">
+                                        <i class="<?= $menuItem['icon'] ?> nav-icon"></i>
                                         <?php if ($menuItem['shortcut']) { ?>
-                                            <span class="badge text-bg-secondary"><?= $menuItem['shortcut'] ?></span>
+                                            <span class="badge p-1 text-bg-secondary"><?= $menuItem['shortcut'] ?></span>
                                         <?php } ?>
                                         <?= $menuTitle ?>
                                     </span>

--- a/layout/basic/component/sidebar.php
+++ b/layout/basic/component/sidebar.php
@@ -90,10 +90,10 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                                 data-placement="left"
                                 <?= ($hasSub) ? 'role="button" data-bs-toggle="collapse" data-bs-target="#' . $menuToggleId . '" aria-expanded="false" aria-controls="' . $menuToggleId . '"' : '' ?>
                             >
-                                <i class="<?= $menuItem['icon'] ?> nav-icon"></i>
-                                <span class="nav-link-title">
+                                <span class="d-flex align-items-center gap-2 nav-link-title">
+                                    <i class="<?= $menuItem['icon'] ?> nav-icon"></i>
                                     <?php if ($menuItem['shortcut']) { ?>
-                                        <span class="badge text-bg-secondary"><?= $menuItem['shortcut'] ?></span>
+                                        <span class="badge p-1 text-bg-secondary"><?= $menuItem['shortcut'] ?></span>
                                     <?php } ?>
                                     <?= $menuTitle ?>
                                 </span>

--- a/layout/basic/component/sidebar.php
+++ b/layout/basic/component/sidebar.php
@@ -85,13 +85,13 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
                         ?>
                         <div class="nav-item da-menu--<?= $menuItem['page_id'] ?>">
                             <a
-                                class="nav-link <?= ($menuItem['page_id'] === $page_id) ? 'active' : ''; ?><?= ($hasSub) ? 'dropdown-toggle collapsed collapsed' : '' ?>"
+                                class="nav-link <?= ($menuItem['page_id'] === $page_id) ? ' active ' : ''; ?><?= ($hasSub) ? 'dropdown-toggle collapsed collapsed' : '' ?>"
                                 href="<?= $menuItem['url'] ?>"
                                 data-placement="left"
                                 <?= ($hasSub) ? 'role="button" data-bs-toggle="collapse" data-bs-target="#' . $menuToggleId . '" aria-expanded="false" aria-controls="' . $menuToggleId . '"' : '' ?>
                             >
                                 <i class="<?= $menuItem['icon'] ?> nav-icon"></i>
-                                <span class="nav-link-title" <?= ($hasSub) ? ' onclick="na_href(\'' . $menuUrlOrigin . '\', \'_self\');"' : '' ?>>
+                                <span class="nav-link-title">
                                     <?php if ($menuItem['shortcut']) { ?>
                                         <span class="badge text-bg-secondary"><?= $menuItem['shortcut'] ?></span>
                                     <?php } ?>

--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -403,8 +403,6 @@ a:hover {
 
 .na-menu .nav-icon {
   opacity: 0.7;
-  -ms-flex: 0 0 1.9375rem;
-  flex: 0 0 1.9375rem;
 }
 
 .na-menu .nav-pills {
@@ -519,6 +517,10 @@ a:hover {
 .na-menu .nav-pills .nav-link.active:hover,
 .na-menu .nav-pills .show > .nav-link:hover {
   border-color: transparent;
+}
+
+.na-menu .nav-pills .nav-link .nav-link-title .badge {
+  width: 1.3rem;
 }
 
 @media (max-width: 992px) {

--- a/layout/basic/inc.menu.php
+++ b/layout/basic/inc.menu.php
@@ -104,10 +104,11 @@ return [
         'title' => '소모임',
         'items' => [
             '소모임' => [
-                'url' => '/bbs/group.php?gr_id=group',
+                'url' => G5_BBS_URL . '/group.php?gr_id=group',
                 'page_id' => G5_BBS_DIR . '-group-group',
                 'shortcut' => 'Ｓ',
                 'items' => [
+                    '모아보기' => G5_BBS_URL . '/group.php?gr_id=group',
                     'AI당' => '/ai',
                     'LOL당' => '/lol',
                     'OTT당' => '/ott',

--- a/layout/basic/inc.menu.php
+++ b/layout/basic/inc.menu.php
@@ -1,5 +1,8 @@
 <?php
 
+// 전각 문자표
+// ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ
+
 return [
     [
         'title' => ($member['mb_level'] >= 5) ?'Nerv' : "",
@@ -34,14 +37,14 @@ return [
             ],
             '앙지도' => [
                 'url' => '/angmap',
-                'shortcut' => 'M',
+                'shortcut' => 'Ｍ',
                     'icon' => 'bi-star-fill',
 
                 // Ａ단축키는 알림 링크에 사용됨
             ],
             '삐앙삐앙' => [
                 'url' => '/angreport',
-                'shortcut' => 'X',
+                'shortcut' => 'Ｘ',
                     'icon' => 'bi-webcam-fill',
 
                 // Ａ단축키는 알림 링크에 사용됨
@@ -93,7 +96,7 @@ return [
             '레퍼럴' => [
                 'url' => '/referral',
                 // 'icon' => 'bi-cart-plus-fill',
-                'shortcut' => 'O',
+                'shortcut' => 'Ｏ',
             ],
         ]
     ],
@@ -210,7 +213,7 @@ return [
             ],
             '레벨강등 열람' => [
                 'url' => '/disciplinelog',
-                'shortcut' => 'Y',
+                'shortcut' => 'Ｙ',
                 'icon' => 'bi-person-fill-dash',
             ],
         ],

--- a/layout/basic/js/customui.js
+++ b/layout/basic/js/customui.js
@@ -1264,9 +1264,9 @@
           var shortcut_div = document.createElement("div");
           shortcut_div.className = "nav-item shortcut_custom";
           var shortcut_link = document.createElement("a");
-          shortcut_link.className = "nav-link shortcut_custom";
+          shortcut_link.className = "nav-link shortcut_custom d-flex align-items-center gap-2 nav-link-title";
           shortcut_link.href = "/" + board_obj.board + "?sfl=mb_id%2C" + i + "&stx=" + board_obj.id;
-          shortcut_link.innerHTML = '<i class="' + temp_icon[i] + ' nav-icon"></i>&nbsp;' + temp_text[i];
+          shortcut_link.innerHTML = '<i class="' + temp_icon[i] + ' nav-icon"></i>' + temp_text[i];
           shortcut_div.appendChild(shortcut_link);
           sidebar_site_menu.insertBefore(shortcut_div, sidebar_site_menu_first);
           offcanvas_menu.insertBefore(shortcut_div.cloneNode(true), offcanvas_menu_first);
@@ -1281,9 +1281,9 @@
           var shortcut_div = document.createElement("div");
           shortcut_div.className = "nav-item shortcut_custom";
           var shortcut_link = document.createElement("a");
-          shortcut_link.className = "nav-link shortcut_custom";
+          shortcut_link.className = "nav-link shortcut_custom d-flex align-items-center gap-2 nav-link-title";
           shortcut_link.href = link_map[shortcut].org;
-          shortcut_link.innerHTML = '<i class="bi-list-stars nav-icon"></i> <span class="badge text-bg-secondary">' + shortcut_i + '</span>&nbsp;' + link_map[shortcut].name;
+          shortcut_link.innerHTML = '<i class="bi-list-stars nav-icon"></i> <span class="badge p-1 text-bg-secondary" style="width: 1.3rem;">' + shortcut_i + '</span>' + link_map[shortcut].name;
           shortcut_div.appendChild(shortcut_link);
           sidebar_site_menu.insertBefore(shortcut_div, sidebar_site_menu_first);
           offcanvas_menu.insertBefore(shortcut_div.cloneNode(true), offcanvas_menu_first);


### PR DESCRIPTION
메뉴의 아이콘, 단축키 표시, 메뉴명을 정렬하고 단축키 표시를 고정된 너비로 표시하게 개선했습니다.

AS-IS
<img width="257" alt="스크린샷 2024-05-29 오후 10 45 30" src="https://github.com/damoang/theme/assets/112419763/0ce397e6-a754-4384-bad0-b94bc9be87d6">


TO-BE
<img width="281" alt="스크린샷 2024-05-29 오후 10 49 26" src="https://github.com/damoang/theme/assets/112419763/945180eb-4344-4209-b483-77b7fc38b55a">
