### PR TITLE
새 알림이 있을 때 toast 대신 헤더 영역에 아이콘에 표시하도록 변경

### DIFF
--- a/layout/basic/component/noti.offcanvas.php
+++ b/layout/basic/component/noti.offcanvas.php
@@ -76,28 +76,13 @@ if (!defined('_GNUBOARD_')) {
     </div>
 </div>
 
-<div class="noti-toast toast fade hide align-items-center fixed-bottom m-3" aria-live="polite" aria-atomic="true" data-bs-delay="10000" role="alert">
-    <div class="d-flex align-items-center">
-        <div class="toast-body">
-            <div class="spinner-grow spinner-grow-sm text-primary" role="status">
-                <span class="visually-hidden">Check it!</span>
-            </div>
-            <a href="javascript:;" data-bs-toggle="offcanvas" data-bs-target="#notiOffcanvas" aria-controls="notiOffcanvas">
-                <strong class="noti-count"></strong>개의 알림이 도착했습니다.
-            </a>
-        </div>
-        <button type="button" class="btn-close me-2 m-auto nofocus" data-bs-dismiss="toast" aria-label="Close"></button>
-    </div>
-</div>
-
 <script>
 function noti_count() {
     $.get('<?php echo LAYOUT_URL ?>/component/noti.offcanvas.php?cnt=1', function(data) {
         if (data.count > 0) {
-            $('.noti-count').text(number_format(data.count));
-            $('.noti-toast').removeClass('hide').addClass('show');
+            $('.da-noti-indicator').removeClass('d-none');
         } else {
-            $('.noti-toast').removeClass('show').addClass('hide');
+            $('.da-noti-indicator').addClass('d-none');
         }
     }, "json");
     return false;

--- a/layout/basic/head.php
+++ b/layout/basic/head.php
@@ -31,40 +31,6 @@ if(IS_INDEX)
                     include_once LAYOUT_PATH.'/component/menu.php';
                     ?>
                 </div>
-
-                <div class="dropdown">
-                    <a href="#dark" id="bd-theme" data-bs-toggle="dropdown" aria-expanded="false" class="site-icon">
-                        <span class="theme-icon-active" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="다크모드">
-                            <i class="bi bi-sun"></i>
-                            <span class="visually-hidden">다크모드</span>
-                        </span>
-                    </a>
-                    <div class="dropdown-menu dropdown-menu-end py-0 shadow-none border navbar-dropdown-caret theme-dropdown-menu" aria-labelledby="bd-theme" data-bs-popper="static">
-                        <div class="card position-relative border-0">
-                            <div class="card-body p-1">
-                                <button type="button" class="dropdown-item rounded-1" data-bs-theme-value="light">
-                                    <span class="me-2 theme-icon">
-                                        <i class="bi bi-sun"></i>
-                                    </span>
-                                    Light
-                                </button>
-                                <button type="button" class="dropdown-item rounded-1 my-1" data-bs-theme-value="dark">
-                                    <span class="me-2 theme-icon">
-                                        <i class="bi bi-moon-stars"></i>
-                                    </span>
-                                    Dark
-                                </button>
-                                <button type="button" class="dropdown-item rounded-1" data-bs-theme-value="auto">
-                                    <span class="me-2 theme-icon">
-                                        <i class="bi bi-circle-half"></i>
-                                    </span>
-                                    Auto
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
                 <div>
                     <a href="#newOffcanvas" data-bs-toggle="offcanvas" data-bs-target="#newOffcanvas" aria-controls="newOffcanvas" class="site-icon">
                         <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="새글/새댓글">

--- a/layout/basic/head.php
+++ b/layout/basic/head.php
@@ -92,6 +92,19 @@ if(IS_INDEX)
                     </a>
                 </div>
                 <div>
+                    <a href="#notiOffcanvas" data-bs-toggle="offcanvas" data-bs-target="#notiOffcanvas" aria-controls="notiOffcanvas" class="site-icon">
+                        <?php
+                        ?>
+                        <span class="position-relative" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="알림">
+                            <i class="bi <?= ($is_member) ? 'bi-bell' : 'bi-person-circle' ?>"></i>
+                            <span class="position-absolute top-0 start-100 translate-middle spinner-grow spinner-grow bg-primary d-none da-noti-indicator" style="--bs-spinner-width: 5px; --bs-spinner-height: 5px;">
+                                <span class="visually-hidden">새 알림이 있습니다</span>
+                            </span>
+                            <span class="visually-hidden">알림 보기</span>
+                        </span>
+                    </a>
+                </div>
+                <div>
                     <a href="#menuOffcanvas" data-bs-toggle="offcanvas" data-bs-target="#menuOffcanvas" aria-controls="menuOffcanvas">
                         <span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="메뉴">
                             <i class="bi bi-list fs-4"></i>

--- a/layout/basic/tail.php
+++ b/layout/basic/tail.php
@@ -93,21 +93,51 @@ if (!IS_INDEX) {
             <i class="bi bi-house-door"></i>
             <span class="visually-hidden">홈으로</span>
         </a>
-    <a href="#menuOffcanvas" class="btn-menu btn btn-basic btn-sm" data-bs-toggle="offcanvas"
+        <a href="#menuOffcanvas" class="btn-menu btn btn-basic btn-sm" data-bs-toggle="offcanvas"
         data-bs-target="#menuOffcanvas" aria-controls="menuOffcanvas" title="전체메뉴">
             <i class="bi bi-list"></i>
             <span class="visually-hidden">전체메뉴</span>
         </a>
-    <a href="#loginOffcanvas" class="btn-member btn btn-basic btn-sm" data-bs-toggle="offcanvas"
+        <a href="#loginOffcanvas" class="btn-member btn btn-basic btn-sm" data-bs-toggle="offcanvas"
         data-bs-target="#memberOffcanvas" aria-controls="memberOffcanvas" title="마이메뉴">
             <i class="bi bi-person-circle"></i>
             <span class="visually-hidden">마이메뉴</span>
         </a>
-    <a href="#newOffcanvas" class="btn-new btn btn-basic btn-sm" data-bs-toggle="offcanvas"
+        <a href="#newOffcanvas" class="btn-new btn btn-basic btn-sm" data-bs-toggle="offcanvas"
         data-bs-target="#newOffcanvas" aria-controls="newOffcanvas" title="새글/새댓글">
             <i class="bi bi-lightning"></i>
             <span class="visually-hidden">새글/새댓글</span>
         </a>
+        <div class="dropdown" data-bs-toggle="dropdown" aria-expanded="false" class="site-icon">
+            <a href="#dark" class="btn btn-basic btn-sm " id="bd-theme">
+                <i class="bi bi-sun"></i>
+                <span class="visually-hidden">테마 변경</span>
+            </a>
+            <div class="dropdown-menu dropdown-menu-end py-0 shadow-none border navbar-dropdown-caret theme-dropdown-menu" aria-labelledby="bd-theme" data-bs-popper="static">
+                <div class="card position-relative border-0">
+                    <div class="card-body p-1">
+                        <button type="button" class="dropdown-item rounded-1" data-bs-theme-value="light">
+                            <span class="me-2 theme-icon">
+                                <i class="bi bi-sun"></i>
+                            </span>
+                            Light
+                        </button>
+                        <button type="button" class="dropdown-item rounded-1 my-1" data-bs-theme-value="dark">
+                            <span class="me-2 theme-icon">
+                                <i class="bi bi-moon-stars"></i>
+                            </span>
+                            Dark
+                        </button>
+                        <button type="button" class="dropdown-item rounded-1" data-bs-theme-value="auto">
+                            <span class="me-2 theme-icon">
+                                <i class="bi bi-circle-half"></i>
+                            </span>
+                            Auto
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
         <?php if (IS_YC) { ?>
             <?php if (IS_SHOP) { ?>
                 <a href="<?php echo G5_URL ?>" class="btn btn-basic btn-sm">


### PR DESCRIPTION
커뮤니티의 불만이 많았던 알림 기능을 토스트 알림을 제거하고 헤더 영역 아이콘으로 표시하도록 변경했습니다.

알림 아이콘이 추가되어 좁아진 아이콘 영역에서 테마 컬러셋 변경 버튼을 메뉴 패널로 옮겼습니다.

<img width="470" alt="스크린샷 2024-05-30 오전 12 46 13" src="https://github.com/damoang/theme/assets/112419763/7cfed833-86e7-43e3-abff-64d8e46d7544">
