### PR TITLE
메인, 게시판목록 추천수 컬러세트 지정 및 노출 위치 수정

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -689,3 +689,57 @@ div a mark:hover {
   left: unset;
   top: unset;
 }
+
+
+/*추천수 메인*/
+.rcmd-sm {
+  width: 35px !important;
+  min-width: 35px !important;
+  margin: 0px !important;
+}
+
+/*추천수 박스*/
+.rcmd-box {
+  border-radius: 5px;
+  width: 40px;
+  color: #333333;
+  font-weight: 400;
+  text-align: center;
+  font-size: 12px;
+  margin: auto;
+}
+
+/* 추천수 스텝별 옵션 */
+.rcmd-box.step1 {
+  background-color: #dddddd !important;
+}
+
+.rcmd-box.step2 {
+  background-color: #b3ffa2 !important;
+}
+
+.rcmd-box.step3 {
+  background-color: #ffd57a !important;
+}
+
+.rcmd-box.step4 {
+  background-color: #e24a4a !important;
+  color: #ffffff;
+}
+
+/* 추천수 PC, Mobile 제어 */
+.rcmd-pc {
+  display: block !important;
+  min-width: 60px;
+}
+.rcmd-mb {
+  display: none !important;
+}
+@media (max-width: 767px) {
+  .rcmd-pc {
+    display: none !important;
+  }
+  .rcmd-mb {
+    display: block !important;
+  }
+}

--- a/layout/basic/widget/wr-list-recommend/widget.php
+++ b/layout/basic/widget/wr-list-recommend/widget.php
@@ -83,11 +83,11 @@ $wr_notice = (isset($wset['is_notice']) && $wset['is_notice']) ? ' bg-body-terti
                 <!--  추천수에 따른 컬러세트 지정(메인) -->
                 <?php
                     $rcmd_step = "rcmd-box step1";
-                    if($row['wr_good'] <= 5) {
+                    if($row['wr_good'] <= 15) {
                         $rcmd_step = "rcmd-box step1";
-                    }else if($row['wr_good'] > 5 && $row['wr_good'] <=10) {
+                    }else if($row['wr_good'] > 15 && $row['wr_good'] <= 25) {
                         $rcmd_step = "rcmd-box step2";
-                    }else if($row['wr_good'] > 10 && $row['wr_good'] <=50) {
+                    }else if($row['wr_good'] > 25 && $row['wr_good'] <= 50) {
                         $rcmd_step = "rcmd-box step3";
                     }else if($row['wr_good'] > 50) {
                         $rcmd_step = "rcmd-box step4";

--- a/layout/basic/widget/wr-list-recommend/widget.php
+++ b/layout/basic/widget/wr-list-recommend/widget.php
@@ -80,7 +80,20 @@ $wr_notice = (isset($wset['is_notice']) && $wset['is_notice']) ? ' bg-body-terti
             <div class="d-flex align-items-center gap-1">
                 <?php if (!$row['is_notice']) { ?>
                 <!-- 추천 수 -->
-                <span class="badge text-bg-secondary"><?= intval($row['wr_good'] ?? 0) ?></span>
+                <!--  추천수에 따른 컬러세트 지정(메인) -->
+                <?php
+                    $rcmd_step = "rcmd-box step1";
+                    if($row['wr_good'] <= 5) {
+                        $rcmd_step = "rcmd-box step1";
+                    }else if($row['wr_good'] > 5 && $row['wr_good'] <=10) {
+                        $rcmd_step = "rcmd-box step2";
+                    }else if($row['wr_good'] > 10 && $row['wr_good'] <=50) {
+                        $rcmd_step = "rcmd-box step3";
+                    }else if($row['wr_good'] > 50) {
+                        $rcmd_step = "rcmd-box step4";
+                    }
+                ?>
+                <span class="<?php echo $rcmd_step ?> rcmd-sm"><?= intval($row['wr_good'] ?? 0) ?></span>
                 <?php } ?>
                 <!-- 제목 -->
                 <div class="text-truncate">

--- a/skin/board/basic/category/basic/category.skin.php
+++ b/skin/board/basic/category/basic/category.skin.php
@@ -136,18 +136,6 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
         </form>
     </div>
     <?php if ($write_href && !$wr_id) { ?>
-        <!-- <div class="order-last">
-            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C1&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
-                <i class="bi bi-chat-square-text"></i>
-                내 글
-            </a>
-        </div>
-        <div class="order-last">
-            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C0&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
-                <i class="bi bi-chat"></i>
-                내 댓글
-            </a>
-        </div> -->
         <div class="order-last">
             <a href="<?php echo $write_href ?>" class="btn btn-primary btn-sm">
                 <i class="bi bi-pencil"></i>

--- a/skin/board/basic/category/basic/category.skin.php
+++ b/skin/board/basic/category/basic/category.skin.php
@@ -136,6 +136,18 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
         </form>
     </div>
     <?php if ($write_href && !$wr_id) { ?>
+        <!-- <div class="order-last">
+            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C1&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
+                <i class="bi bi-chat-square-text"></i>
+                내 글
+            </a>
+        </div>
+        <div class="order-last">
+            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C0&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
+                <i class="bi bi-chat"></i>
+                내 댓글
+            </a>
+        </div> -->
         <div class="order-last">
             <a href="<?php echo $write_href ?>" class="btn btn-primary btn-sm">
                 <i class="bi bi-pencil"></i>

--- a/skin/board/basic/list/list/list.skin.php
+++ b/skin/board/basic/list/list/list.skin.php
@@ -9,9 +9,14 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
     <ul class="list-group list-group-flush border-bottom">
         <li class="list-group-item d-none d-md-block hd-wrap">
             <div class="d-flex flex-md-row align-items-md-center gap-1 fw-bold">
-                <div class="col-1 text-center">
+                <?php if($is_good) { ?>
+                    <div class="hd-num text-center">
+                        <?php echo subject_sort_link('wr_good', $qstr2, 1) ?>추천</a>
+                    </div>
+                <?php } ?>
+                <!-- <div class="col-1 text-center">
                     번호
-                </div>
+                </div> -->
                 <div class="text-center flex-grow-1">
                     제목
                 </div>
@@ -23,11 +28,6 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                         <div class="hd-date text-center">
                             <?php echo subject_sort_link('wr_datetime', $qstr2, 1) ?>날짜</a>
                         </div>
-                        <?php if($is_good) { ?>
-                            <div class="hd-num text-center">
-                                <?php echo subject_sort_link('wr_good', $qstr2, 1) ?>추천</a>
-                            </div>
-                        <?php } ?>
                         <div class="hd-num text-center">
                             <?php echo subject_sort_link('wr_hit', $qstr2, 1) ?>조회</a>
                         </div>
@@ -88,14 +88,39 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                 $li_css = ' bg-light-subtle';
                 $row['subject'] = '<strong class="fw-medium">'.$row['subject'].'</strong>';
                 $row['num'] = '<span class="orangered">공지</span>';
+                $row['wr_good'] = '공지';
             }
         ?>
             <li class="list-group-item da-link-block <?php echo $li_css; ?>">
 
                 <div class="d-flex align-items-center gap-1">
-                    <div class="col-1 wr-no d-none d-md-block">
-                        <?php echo $row['num'] ?>
-                    </div>
+                    <?php if($is_good) { ?>
+                        <!--  추천수에 따른 컬러세트 지정(게시판 목록) -->
+                        <?php
+                            $rcmd_step = "rcmd-box step1";
+                            if($row['wr_good'] == '공지') {
+                                $rcmd_step = "orangered"; //공지사항은 추천수 표시하지 않고 "공지" 텍스트 출력
+                            }else if($row['wr_good'] <= 5) {
+                                $rcmd_step = "rcmd-box step1";
+                            }else if($row['wr_good'] > 5 && $row['wr_good'] <=10) {
+                                $rcmd_step = "rcmd-box step2";
+                            }else if($row['wr_good'] > 10 && $row['wr_good'] <=50) {
+                                $rcmd_step = "rcmd-box step3";
+                            }else if($row['wr_good'] > 50) {
+                                $rcmd_step = "rcmd-box step4";
+                            }
+                        ?>
+                        <div class="wr-num text-nowrap rcmd-pc">
+                            <i class="bi bi-hand-thumbs-up d-inline-block d-md-none"></i>
+                            <div class="<?php echo $rcmd_step ?>">
+                            <?php echo $row['wr_good'] ?>
+                            </div>
+                            <span class="visually-hidden">추천</span>
+                        </div>
+                    <?php } ?>
+                    <!-- <div class="col-1 wr-no d-none d-md-block">
+                        <?//php echo $row['num'] ?>
+                    </div> -->
                     <?php if ($is_checkbox) { ?>
                         <div>
                             <input class="form-check-input me-1" type="checkbox" name="chk_wr_id[]" value="<?php echo $row['wr_id'] ?>" id="chk_wr_id_<?php echo $i ?>">
@@ -152,7 +177,7 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                                         <span class="visually-hidden">등록</span>
                                     </div>
                                     <?php if($is_good) { ?>
-                                        <div class="wr-num text-nowrap order-3">
+                                        <div class="wr-num text-nowrap order-3 rcmd-mb">
                                             <i class="bi bi-hand-thumbs-up d-inline-block d-md-none"></i>
                                             <?php echo $row['wr_good'] ?>
                                             <span class="visually-hidden">추천</span>


### PR DESCRIPTION
![dmg_추천수_메인](https://github.com/damoang/theme/assets/3017941/1a9af6dd-5b34-4dc3-9ff7-cb35a8d5e1bf)
![dmg_추천수_게시판](https://github.com/damoang/theme/assets/3017941/16cecfe9-13c9-47d3-8d88-71a322dba8ab)

[개선 요청사항]
게시판 목록의 추천수를 앞에 배치하고 크게 의미 없는 글 번호는 뒤로 빼거나 제거

[조치]
1. 추천수를 맨 앞으로 배치

2. 글 번호는 삭제
- PC, 모바일 통틀어 글번호를 유의미하게 사용하는 곳은 없는 것으로 보임(모바일은 이미 글 번호 노출하지 않고 있음)
- 일단, 완전 삭제하지 않고 글 번호는 주석 처리하여 보이지 않게 처리
- 의견 청취 후 완전 삭제 또는 되살리는 방향으로 진행

3. 추천수에 따라 컬러세트 지정(메인 추천수, 게시판 목록 추천수)
- 총 4단계에 걸쳐 컬러를 지정함
- 5개 이하, 5개 초과 10개 이하, 10개 초과 50개 이하, 50개 초과
- 색상은 다크/라이트 고려하여 적당한 색상으로 지정하였으며 추 후 색상에 대한 의견이 있을 경우 보완 조치함

4. 공지글은 추천수를 표시하지 않고 "공지" 텍스트로 표시함