### PR TITLE
모바일에서 제목 하단 영역 정렬 안 맞는 문제 조치, 자신이 작성한 글 강조,내글 내댓글 조회버튼 추가

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -831,6 +831,7 @@ div a mark:hover {
 }
 .rcmd-mb {
   display: none !important;
+  margin: inherit;
 }
 @media (max-width: 767px) {
   .rcmd-pc {

--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -841,3 +841,36 @@ div a mark:hover {
     display: block !important;
   }
 }
+
+@media (max-width: 560px) {
+  footer .bar-sm,footer i.bar{
+    margin: 0px 2px !important;
+    display: inline-block;
+  }
+
+  footer .container {
+      gap: 0.1rem;
+      font-size: clamp(12px, 1.5vw, 14px);
+  }
+
+  footer .container a {
+    white-space: nowrap;
+  }
+}
+
+
+@media (max-width: 450px) {
+  footer .bar-sm,footer i.bar{
+    margin: 0px 2px !important;
+    display: inline-block;
+  }
+
+  footer .container {
+      gap: 0.1rem;
+      font-size: clamp(9px, 1.5vw, 14px);
+  }
+
+  footer .container a {
+       white-space: nowrap;
+  }
+}

--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -842,35 +842,16 @@ div a mark:hover {
   }
 }
 
-@media (max-width: 560px) {
-  footer .bar-sm,footer i.bar{
-    margin: 0px 2px !important;
-    display: inline-block;
-  }
-
-  footer .container {
-      gap: 0.1rem;
-      font-size: clamp(12px, 1.5vw, 14px);
-  }
-
-  footer .container a {
-    white-space: nowrap;
-  }
+footer .bar-sm,footer i.bar{
+  margin: 0px 2px !important;
+  display: inline-block;
 }
 
+footer .container {
+    gap: 0.1rem;
+    font-size: clamp(9px, 2.5vw, 14px);
+}
 
-@media (max-width: 450px) {
-  footer .bar-sm,footer i.bar{
-    margin: 0px 2px !important;
-    display: inline-block;
-  }
-
-  footer .container {
-      gap: 0.1rem;
-      font-size: clamp(9px, 1.5vw, 14px);
-  }
-
-  footer .container a {
-       white-space: nowrap;
-  }
+footer .container a {
+  white-space: nowrap;
 }

--- a/layout/basic/tail.php
+++ b/layout/basic/tail.php
@@ -31,8 +31,7 @@ if (!IS_INDEX) {
 
 <footer class="site-footer-wrap bg-body-tertiary py-4">
     <div class="container px-3 text-center">
-
-        <div class="mb-4">
+        <div class="mb-2">
             <a href="<?php echo get_pretty_url('content', 'company'); ?>">
                 사이트 소개
                 <i class="bar">&nbsp;</i>
@@ -58,7 +57,7 @@ if (!IS_INDEX) {
             </a>
         </div>
 
-        <div class="lh-lg mb-3">
+        <div class="lh-lg mb-1">
             회사명 : <?php echo $default['de_admin_company_name'] ?>
             <span class="bar-sm">&nbsp;</span>
             대표 : <?php echo $default['de_admin_company_owner'] ?>
@@ -66,10 +65,11 @@ if (!IS_INDEX) {
             사업자 등록번호 : <?php echo $default['de_admin_company_saupja_no'] ?>
 
         </div>
-        <div class="lh-lg mb-3">
+        <div class="mb-2">
             주소 : <?php echo $default['de_admin_company_addr'] ?>
         </div>
-        contact : contact@damoang.net
+
+            <div>contact : contact@damoang.net</div>
 
         <div class="small">
             Copyright &copy; <b><?php $host = @parse_url(G5_URL); echo $host['host'] ?></b>. All rights reserved.

--- a/skin/board/basic/category/basic/category.skin.php
+++ b/skin/board/basic/category/basic/category.skin.php
@@ -137,6 +137,18 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
     </div>
     <?php if ($write_href && !$wr_id) { ?>
         <div class="order-last">
+            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C0&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
+                <i class="bi bi-chat-square-text"></i>
+                <span class="d-none d-sm-inline-block">내 글</span>
+            </a>
+        </div>
+        <div class="order-last">
+            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C1&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
+                <i class="bi bi-chat"></i>
+                <span class="d-none d-sm-inline-block">내 댓글</span>
+            </a>
+        </div>
+        <div class="order-last">
             <a href="<?php echo $write_href ?>" class="btn btn-primary btn-sm">
                 <i class="bi bi-pencil"></i>
                 쓰기

--- a/skin/board/basic/list/list/list.css
+++ b/skin/board/basic/list/list/list.css
@@ -59,3 +59,16 @@
 .list-group-item:active {
   background-color: brightness(var(--bs-list-group-action-active-bg), 0.8) !important;
 }
+
+/* 내가 작성한 글 강조하기 */
+[data-bs-theme=light] {
+  .writter-bg {
+    background-color: #eeeeee !important;
+  }
+}
+
+[data-bs-theme=dark] {
+  .writter-bg {
+    background-color: #131313 !important;
+  }
+}

--- a/skin/board/basic/list/list/list.skin.php
+++ b/skin/board/basic/list/list/list.skin.php
@@ -90,8 +90,14 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                 $row['num'] = '<span class="orangered">공지</span>';
                 $row['wr_good'] = '<span class="orangered">공지</span>';
             }
+
+            // 내가 작성한 글 강조하기
+            $writter_bg = "";
+            if(trim($list[$i]['mb_id']) == trim($member['mb_id'])){
+                $writter_bg = "writter-bg";
+            }
         ?>
-            <li class="list-group-item da-link-block <?php echo $li_css; ?>">
+            <li class="list-group-item da-link-block <?php echo $li_css; ?> <?php echo $writter_bg; ?>">
 
                 <div class="d-flex align-items-center gap-1">
                     <?php if($is_good) { ?>


### PR DESCRIPTION
[증상]
모바일에서 제목 하단의 댓글, 추천수 등의 정보 출력시 균등분할로 보이는 문제 발생

[조치]
margin: auto속성을 모바일에선 적용하지 않도록 처리

[개선사항]
1. 자신이 작성한 글은 글 목록에서 배경색을 강조하여 표시 함
<img width="536" alt="image" src="https://github.com/damoang/theme/assets/3017941/7118cf47-b9ac-406b-8b55-976785b85435">

2. 게시판 목록에 내가 작성한 글, 댓글 조회하는 버튼 추가
<img width="495" alt="image" src="https://github.com/damoang/theme/assets/3017941/febafe07-85cc-4148-93f0-1327bdaaf164">

3. Footer 영역 모바일 뷰 개선
- 폰트 사이즈 9px ~ 14px 범위 내에서 조절되도록 조치, 그 외 약간의 간격 조절
<img width="421" alt="image" src="https://github.com/damoang/theme/assets/3017941/4a8009fd-602d-4d54-b3f1-ba90733e3061">


