### PR TITLE
내글/내댓글 조회시 목록 반대로 나오는 문제 조치

### DIFF
--- a/skin/board/basic/category/basic/category.skin.php
+++ b/skin/board/basic/category/basic/category.skin.php
@@ -137,13 +137,13 @@ if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
     </div>
     <?php if ($write_href && !$wr_id) { ?>
         <div class="order-last">
-            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C0&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
+            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C1&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
                 <i class="bi bi-chat-square-text"></i>
                 <span class="d-none d-sm-inline-block">내 글</span>
             </a>
         </div>
         <div class="order-last">
-            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C1&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
+            <a href="/<?php echo $bo_table;?>?sfl=mb_id%2C0&stx=<?php echo $member['mb_id'];?>" class="btn btn-basic btn-sm">
                 <i class="bi bi-chat"></i>
                 <span class="d-none d-sm-inline-block">내 댓글</span>
             </a>


### PR DESCRIPTION
[문제]
게시판 목록의 내글, 내댓글 버튼 클릭시
내 글 누르면 댓글이, 내 댓글 누르면 내 글이 나오고 있습니다.

[조치]
내 글, 내 댓글 조회시 보내는 코드 반대로 변경합니다.