### PR TITLE
모바일 목록 UI 개선

### DIFF
--- a/layout/basic/css/style.css
+++ b/layout/basic/css/style.css
@@ -831,6 +831,8 @@ div a mark:hover {
 }
 .rcmd-mb {
   display: none !important;
+  padding-left: .3rem !important;
+  padding-right: .3rem !important;
 }
 @media (max-width: 767px) {
   .rcmd-pc {
@@ -838,5 +840,12 @@ div a mark:hover {
   }
   .rcmd-mb {
     display: block !important;
+  }
+  /* 모바일 색상 */
+  .da-list-meta, .da-list-meta .sv_member {
+    color: rgba(var(--bs-body-color-rgb), .6);
+  }
+  .da-list-date {
+    color: inherit !important;
   }
 }

--- a/skin/board/basic/list/list/list.skin.php
+++ b/skin/board/basic/list/list/list.skin.php
@@ -133,7 +133,19 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                     <?php } ?>
                     <div class="flex-grow-1 overflow-hidden">
                         <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
-                            <div class="d-inline-flex flex-fill overflow-hidden">
+                            <div class="d-inline-flex flex-fill overflow-hidden align-items-center">
+                                <!-- 추천 수 (모바일) -->
+                                <?php if($is_good && $row['wr_good'] > 0) { ?>
+                                    <div class="wr-num da-rcmd text-nowrap d-md-none me-2 d-none">
+                                        <div class="<?php echo $rcmd_step ?> rcmd-mb w-auto">
+                                        <?php if(!strpos($row['wr_good'], '공지')) { ?>
+                                            <i class="bi bi-hand-thumbs-up" style="font-size:.7rem"></i>
+                                        <?php } ?>
+                                        <?php echo $row['wr_good'] ?>
+                                        </div>
+                                        <span class="visually-hidden">추천</span>
+                                    </div>
+                                <?php } ?>
                                 <?php
                                 // 회원만 보기
                                 echo $row['da_member_only'] ?? '';
@@ -166,22 +178,28 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                                     <span class="float-end"><?= $row['da_member_memo'] ?></span>
                                 <?php } ?>
                             </div>
-                            <div class="">
+                            <div class="da-list-meta">
                                 <div class="d-flex gap-2">
-                                    <div class="order-1 wr-name">
+                                    <div class="wr-name ms-auto order-last order-md-1">
                                         <?php
                                             $wr_name = ($row['mb_id']) ? str_replace('sv_member', 'sv_member text-truncate d-block', $row['name']) : str_replace('sv_guest', 'sv_guest text-truncate d-block', $row['name']);
                                             echo na_name_photo($row['mb_id'], $wr_name);
                                         ?>
                                     </div>
-                                    <div class="wr-date ms-auto text-nowrap order-last order-md-2">
-                                        <?php echo na_date($row['wr_datetime'], 'orangered', 'H:i', 'm.d', 'Y.m.d') ?>
+                                    <div class="wr-date text-nowrap order-5 order-md-2">
+                                        <i class="bi bi-clock d-inline-block d-md-none"></i>
+                                        <?php echo na_date($row['wr_datetime'], 'orangered da-list-date', 'H:i', 'm.d', 'Y.m.d') ?>
                                         <span class="visually-hidden">등록</span>
                                     </div>
-                                    <?php if($is_good) { ?>
-                                        <div class="wr-num text-nowrap order-3 rcmd-mb">
-                                            <i class="bi bi-hand-thumbs-up d-inline-block d-md-none"></i>
+                                    <!-- 추천 수 (모바일) -->
+                                    <?php if($is_good && $row['wr_good'] > 0) { ?>
+                                        <div class="wr-num da-rcmd text-nowrap d-md-none">
+                                            <div class="<?php echo $rcmd_step ?> rcmd-mb w-auto">
+                                            <?php if(!strpos($row['wr_good'], '공지')) { ?>
+                                                <i class="bi bi-hand-thumbs-up" style="font-size:.7rem"></i>
+                                            <?php } ?>
                                             <?php echo $row['wr_good'] ?>
+                                            </div>
                                             <span class="visually-hidden">추천</span>
                                         </div>
                                     <?php } ?>
@@ -189,6 +207,11 @@ add_stylesheet('<link rel="stylesheet" href="'.$list_skin_url.'/list.css">', 0);
                                         <i class="bi bi-eye d-inline-block d-md-none"></i>
                                         <?php echo $row['wr_hit'] ?>
                                         <span class="visually-hidden">조회</span>
+                                    </div>
+                                    <div class="wr-num text-nowrap order-2 d-md-none d-none da-list-meta--comments">
+                                        <i class="bi bi-chat-dots d-inline-block d-md-none"></i>
+                                        <?php echo $row['wr_comment'] ?>
+                                        <span class="visually-hidden">댓글</span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
https://discord.com/channels/1223276360060108851/1247003869318483978

표가 많은 2안을 기준으로 합니다.

나머지도 소중하다고 생각되어 모두 컨트롤 할 수 있도록 준비했습니다.

이 부분은 커스텀 UI 담당자분께 맡기겠습니다.

## 1안

### 제목 부분 class 변경
- 추천 수 (모바일)
  - `me-2 d-none` 제거
  - `order-last ms-auto` 추가
- 댓글 수
  - `d-none d-md-inline-block` 추가

### 제목 아래 부분 class 변경
- 추천 수
  - `d-none` 추가
- 댓글 수
  - `d-none` 제거

## 3안

### 제목 부분 class 변경
- 추천 수 (모바일)
  - `d-none` 제거
  - 따봉 아이콘에 `d-none` 추가
- 댓글 수
  - `d-none d-md-inline-block` 추가

### 제목 아래 부분 class 변경
- 이름
  - `ms-auto order-last` -> `me-auto order-1` 변경
  - 하위 `.profile_img`에 `d-none d-md-inline-block` 추가
- 추천 수
  - `d-none` 추가
- 댓글 수
  - `d-none` 제거
