### PR TITLE
글조회시 추천수/스크랩/공유/신고/차단 버튼그룹 사이즈 조정

### DIFF
--- a/skin/board/basic/view/basic/view.skin.php
+++ b/skin/board/basic/view/basic/view.skin.php
@@ -294,7 +294,7 @@ add_stylesheet('<link rel="stylesheet" href="' . $board_skin_url . '/style.css">
         }
         ?>
         <div class="pt-5 pb-4 text-center">
-            <div id="bo_v_act" class="btn-group" role="group">
+            <div id="bo_v_act" class="btn-group btn-group-sm" role="group">
                 <?php if ($board['bo_use_good']) { ?>
                     <button type="button"
                             onclick="na_good('<?php echo $bo_table ?>', '<?php echo $wr_id ?>', 'good', 'wr_good');"


### PR DESCRIPTION
[중상]
모바일에서 글 조회시 버튼그룹에 줄 바꿈이 발생함

[조치]
버튼 그룸의 사이즈를 조금 더 작은 사이즈로 조정
btn-group-sm 추가함

수정전
![image](https://github.com/damoang/theme/assets/3017941/1aae9dec-6210-4096-a9ef-d4be89bd426f)

수정후
![image](https://github.com/damoang/theme/assets/3017941/e1767e77-16b8-4f4c-8542-2fb75ba47438)
