### PR TITLE
내가 작성한 댓글 강조

### DIFF
--- a/skin/board/basic/comment/basic/comment.css
+++ b/skin/board/basic/comment/basic/comment.css
@@ -11,3 +11,15 @@
 #bo_vc_sns input {margin:0 5px 0 0}
 #bo_vc_sns img {margin-top:-5px !important;}
 #bo_vc_opt, #bo_vc_sns {height:30px; line-height:30px;}
+
+[data-bs-theme=light] {
+  .bg-comment-writer {
+    background-color: rgba(239, 191, 150, 0.3) !important;
+  }
+}
+
+[data-bs-theme=dark] {
+  .bg-comment-writer {
+    background-color: rgba(1, 5, 86, 0.25) !important;
+  }
+}

--- a/skin/board/basic/comment/basic/comment.skin.php
+++ b/skin/board/basic/comment/basic/comment.skin.php
@@ -106,7 +106,16 @@ var char_max = parseInt(<?php echo $comment_max ?>); // 최대
             $is_comment_reply_edit = ($list[$i]['is_reply'] || $list[$i]['is_edit'] || $list[$i]['is_del']) ? 1 : 0;
 
             $comment_name = get_text($list[$i]['wr_name']);
-            $by_writer = ($view['mb_id'] && $view['mb_id'] == $list[$i]['mb_id']) ? 'bg-secondary-subtle' : 'bg-body-tertiary';
+
+            // 글 작성자가 쓴 댓글, 로그인 한 사용자가 쓴 댓글, 일반 댓글 색상으로 구분하기
+            if (!empty($view['mb_id']) && $view['mb_id'] == $list[$i]['mb_id']) {
+                $by_writer = 'bg-secondary-subtle'; // 글 작성자가 쓴 댓글
+            } elseif (!empty($member['mb_id']) && $member['mb_id'] == $list[$i]['mb_id']) {
+                $by_writer = 'bg-comment-writer'; // 로그인 한 사용자가 쓴 댓글
+            } else {
+                $by_writer = 'bg-body-tertiary'; // 일반 사용자가 쓴 댓글
+            }
+
             $parent_wr_name = $wr_names[$list[$i]['wr_comment'] . ':' . substr($list[$i]['wr_comment_reply'], 0, -1)] ?? '';
 
         ?>


### PR DESCRIPTION
[개선사항]
글 작성자가 등록한 댓글 강조 기능은 있으나
로그인 한 사용자가 자신이 작성한 댓글을 강조하여 보는 기능이 없어서
강조하도록 기능 추가 함.

[조치]
기존에 글 작성자가 등록한 댓글 강조하는 기능에 
로그인 한 사용자가 작성한 댓글을 강조하는 조건을 추가하여 구현

[개선된 화면 : Dark, Light]
<img width="894" alt="image" src="https://github.com/damoang/theme/assets/3017941/9f44e99e-a00a-4071-ad86-243e4b7eeccc">

<img width="892" alt="image" src="https://github.com/damoang/theme/assets/3017941/b6368b4e-3065-40fb-88e0-5e67dc7bd883">
