### PR TITLE
롤링 공지 노출 시간 조절

### DIFF
--- a/skin/board/basic/list.skin.php
+++ b/skin/board/basic/list.skin.php
@@ -232,7 +232,7 @@ function showRollingNoti(key) {
 
     rollingNoti.appendChild(createRollingNotiElement(messages[index], false));
 
-    setInterval(updateRollingNoti, 3000);
+    setInterval(updateRollingNoti, 4000);
   })
   .catch(error => {
     console.error('Error:', error);


### PR DESCRIPTION
[기능수정]
롤링 공지의 노출 시간을 3초에서 4초로 수정합니다.
문장이 길 경우 읽다가 사라지는 느낌이라 약간 시간을 늘렸습니다.