### PR TITLE
광고앙 모음 페이지를 위한 위젯 추가(advertiser.php를 하드코딩 할 필요없도록 수정)

### DIFF
--- a/layout/basic/widget/advertiser/widget.php
+++ b/layout/basic/widget/advertiser/widget.php
@@ -1,0 +1,162 @@
+<?php
+if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
+
+
+/*  damoang-image-banner 위젯 데이터 파일 path */
+// $wfile = (G5_IS_MOBILE) ? 'mo' : 'pc'; // the platform suffix of the widget data file name. 이미 이 변수가 세팅되어있어서 주석처리
+// $widget_file = NA_DATA_PATH . '/widget/w-advertiser-adCollection-' . $wfile . '.php'; //현재 위젯 설정파일 path. 이미 이 변수가 세팅되어있어서 주석처리
+$headBN_widget_file = NA_DATA_PATH . '/widget/w-damoang-image-banner-board-head-' . $wfile . '.php'; // damoang-image-banner 위젯 설정파일 path
+$sideBN_widget_file = NA_DATA_PATH . '/widget/w-damoang-image-banner-side-banner-' . $wfile . '.php'; // damoang-image-banner 위젯 설정파일 path
+
+
+/* setting the data sets of damoang-image-banner widget */
+$wset_headBN = array(); // damoang-image-banner 위젯 설정파일 
+$wset_sideBN = array(); // damoang-image-banner 위젯 설정파일 
+$wset = array(); //현재 위젯 설정파일
+if (is_file($headBN_widget_file))
+    $wset_headBN = na_file_var_load($headBN_widget_file);
+if (is_file($sideBN_widget_file))
+    $wset_sideBN = na_file_var_load($sideBN_widget_file);
+if (is_file($widget_file))
+    $wset = na_file_var_load($widget_file);
+
+
+/** damoang-image-banner 위젯의 긴배너 출력 */
+function GetHeadBnHTML($wset_headBN)
+{
+    $banner_items = '';
+
+    if (isset($wset_headBN['d']))
+    {
+        foreach ($wset_headBN['d']['img'] as $index => $img)
+        {
+            $link = $wset_headBN['d']['link'][$index];
+            $alt = $wset_headBN['d']['alt'][$index];
+            $target = $wset_headBN['d']['target'][$index];
+            $action_name = isset($wset_headBN['action_name']) ? ' data-dd-action-name="' . htmlspecialchars($wset_headBN['action_name']) . '"' : '';
+
+            $banner_items .= '<li class="list-group-item border-0">';
+            $banner_items .= '<a href="' . htmlspecialchars($link) . '" target="' . htmlspecialchars($target) . '"' . $action_name . '>';
+            $banner_items .= '<img src="' . htmlspecialchars($img) . '" alt="' . htmlspecialchars($alt) . '" class="mw-100">';
+            $banner_items .= '</a>';
+            $banner_items .= '</li>';
+        }
+    }
+
+    $html = <<<EOT
+<!-- 긴 배너 --------------------------------------------------------------- -->
+<section class="container mb-5">
+    <h3 class="border-bottom mb-4 pb-2">긴 배너</h3>
+    <ul class="list-group row list-group-flush">
+        $banner_items
+    </ul>
+</section>
+EOT;
+
+    return $html;
+}
+
+/** damoang-image-banner 위젯의 사이드배너 출력 */
+function GetSideBnHTML($wset_sideBN)
+{
+    $banner_items = '';
+
+    if (isset($wset_sideBN['d']))
+    {
+        foreach ($wset_sideBN['d']['img'] as $index => $img)
+        {
+            $link = $wset_sideBN['d']['link'][$index];
+            $alt = $wset_sideBN['d']['alt'][$index];
+            $target = $wset_sideBN['d']['target'][$index];
+            $action_name = isset($wset_sideBN['action_name']) ? ' data-dd-action-name="' . $wset_sideBN['action_name'] . '"' : '';
+
+            $banner_items .= '<li class="col list-group-item border-0">';
+            $banner_items .= '<a href="' . htmlspecialchars($link) . '" target="' . htmlspecialchars($target) . '"' . $action_name . '>';
+            $banner_items .= '<img src="' . htmlspecialchars($img) . '" alt="' . htmlspecialchars($alt) . '" class="mw-100">';
+            $banner_items .= '</a>';
+            $banner_items .= '</li>';
+        }
+    }
+
+    $html = <<<EOT
+<!-- 사이드 배너 ----------------------------------------------------------- -->
+<section class="container my-5">
+    <h3 class="border-bottom mb-4 pb-2">사이드 배너</h3>
+    <ul class="text-center row row-cols-2 list-group list-group-horizontal list-group-flush">
+        $banner_items
+    </ul>
+</section>
+EOT;
+
+    return $html;
+}
+
+/** (현재 위젯 데이터) 직접홍보 리스트 출력  */
+function GetDirectAdvertisersHTML($wset)
+{
+    $advertiser_items = '';
+
+    if (isset($wset['d']['names']))
+    {
+        foreach ($wset['d']['names'] as $name)
+        {
+            $advertiser_items .= '<li class="col list-group-item border-0">' . htmlspecialchars($name) . '</li>';
+        }
+    }
+
+    $html = <<<EOT
+<!-- 직접홍보 -------------------------------------------------------------- -->
+<section class="container my-5">
+    <h3 class="border-bottom mb-4 pb-2">
+        직접홍보 게시판
+        <small class="float-end"><a class="btn btn-sm btn-bd-light rounded-2" href="/promotion">🌻바로가기</a></small>
+    </h3>
+    <ul class="text-center row row-cols-2 row-cols-md-3 list-group list-group-horizontal list-group-flush" style="font-size: 0.875rem;">
+        $advertiser_items
+    </ul>
+</section>
+EOT;
+
+    return $html;
+}
+
+/** 위젯 설정 Edit 버튼 */
+function GetWidgetSettingsHTML($list, $list_cnt, $wset, $setup_href)
+{
+    $html = '';
+
+    if ($list_cnt)
+    {
+        $link = $list[0]['link'] ? $list[0]['link'] : 'javascript:;';
+        $target = $list[0]['target'];
+        $img = $list[0]['img'];
+        $action_name = isset($wset['action_name']) ? ' data-dd-action-name="' . $wset['action_name'] . '"' : '';
+
+        $html .= <<<EOT
+    <div class="mb-4">
+        <a href="$link" target="$target"$action_name>
+            <img src="$img" style="max-width: 100%;" />
+        </a>
+    </div>
+EOT;
+    }
+
+    if ($setup_href)
+    {
+        $html .= <<<EOT
+    <div class="btn-wset py-2">
+        <button onclick="naClipView('$setup_href');" class="btn btn-basic btn-sm">
+            <i class="bi bi-gear"></i> 광고주모음 위젯설정
+        </button>
+    </div>
+EOT;
+    }
+
+    return $html;
+}
+
+/* HTML 출력 */
+echo GetWidgetSettingsHTML($list, $list_cnt, $wset, $setup_href);
+echo GetHeadBnHTML($wset_headBN);
+echo GetSideBnHTML($wset_sideBN);
+echo GetDirectAdvertisersHTML($wset);

--- a/layout/basic/widget/advertiser/widget.setup.php
+++ b/layout/basic/widget/advertiser/widget.setup.php
@@ -1,0 +1,118 @@
+<?php
+if (!defined('_GNUBOARD_'))
+{
+    exit;
+}
+
+$widget = 'advertiser';
+?>
+
+<ul class="list-group">
+    <li class="list-group-item">
+        <div class="form-group row mb-0">
+            <label class="col-sm-2 col-form-label">페이지 설정</label>
+            <div class="col-sm-10">
+                <style>
+                    #widgetData.table {
+                        border-left: 0;
+                        border-right: 0;
+                    }
+
+                    #widgetData thead th {
+                        border-bottom: 0;
+                    }
+
+                    #widgetData th,
+                    #widgetData td {
+                        vertical-align: middle;
+                        border-left: 0;
+                        border-right: 0;
+                    }
+                </style>
+
+                <p class="form-control-plaintext">
+                    <i class="fa fa-caret-right" aria-hidden="true"></i>
+                    긴 배너와 사이드배너는 현재 등록된 광고가 자동으로 표시되고 있습니다. 
+                </p>
+
+                <div class="table-responsive">
+                    <table id="widgetData" class="table table-bordered order-list mb-0">
+                        <thead>
+                            <tr class="bg-light">
+                                <th class="text-center nw-20">직접홍보 names</th>
+                                <th class="text-center nw-4">삭제</th>
+                            </tr>
+                        </thead>
+                        <tbody id="sortable">
+                            <?php
+
+                            // 직접등록 입력폼
+                            $data = array();
+                            $data_cnt = (isset($wset['d']['names']) && is_array($wset['d']['names'])) ? count($wset['d']['names']) : 1;
+
+                            for ($i = 0; $i < $data_cnt; $i++)
+                            {
+                                $n = $i + 1;
+                                $d_names = isset($wset['d']['names'][$i]) ? $wset['d']['names'][$i] : '';
+
+
+                            ?>
+                                <tr class="bg-light<?php echo ($i % 2 != 0) ? '' : '-1'; ?>">
+                                    <td>
+                                        <div class="input-group">
+                                            <input type="text" id="img_<?php echo $n ?>" name="wset[d][names][]" value="<?php echo $d_names ?>" class="form-control" placeholder="직홍게 이름 입력">
+                                        </div>
+                                    </td>
+            
+                                    <td class="text-center">
+                                        <?php if ($i > 0)
+                                        { ?>
+                                            <a href="javascript:;" class="ibtnDel"><i class="fa fa-times-circle fa-2x text-muted"></i></a>
+                                        <?php } ?>
+                                    </td>
+                                </tr>
+                            <?php } ?>
+                        </tbody>
+                    </table>
+                </div>
+
+
+                <div class="text-center mt-3">
+                    <button type="button" class="btn btn-outline-primary btn-lg en" id="addrow">
+                        추가
+                    </button>
+                </div>
+            </div>
+        </div>
+    </li>
+</ul>
+
+<script>
+    $(document).ready(function() {
+        var counter = <?php echo $data_cnt + 1 ?>;
+        $("#addrow").on("click", function() {
+            var trbg = (counter % 2 === 1) ? 'bg-light-1' : 'bg-light';
+            var newRow = $("<tr class=" + trbg + ">");
+            var cols = "";
+
+            cols += '<td>';
+            cols += '	<div class="input-group">';
+            cols += '		<input type="text" id="img_' + counter + '" name="wset[d][names][]" class="form-control" placeholder="직홍게 이름 입력">';
+            cols += '	</div>';
+            cols += '</td>';
+            cols += '<td class="text-center">';
+            cols += '	<a href="javascript:;" class="ibtnDel"><i class="fa fa-times-circle fa-2x text-muted"></i></a>';
+            cols += '</td>';
+
+            newRow.append(cols);
+            $("table.order-list").append(newRow);
+            counter++;
+        });
+
+        $("table.order-list").on("click", ".ibtnDel", function(event) {
+            $(this).closest("tr").remove();
+        });
+
+        $("#sortable").sortable();
+    });
+</script>

--- a/page/advertiser.php
+++ b/page/advertiser.php
@@ -1,197 +1,21 @@
 <?php
-if (!defined('_GNUBOARD_')) {
-    exit;
-}
-?>
-<!-- 긴 배너 --------------------------------------------------------------- -->
-<section class="container mb-5">
-    <h3 class="border-bottom mb-4 pb-2">긴 배너</h3>
-    <ul class="list-group row list-group-flush">
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/oilpangone/products/9013411649" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/editor/2405/comment_237388223_aUnJ5cSX_fc8019b56b15177a0aadee58cd98def4a76a91e8.jpg" alt="오일팡 행주" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/souplab033/products/7792638781" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/015f0b5e4ca48f7d44e78ebd6f62e722_fy36sYPM_4a140bd3f05852b90c5cfe639af9bdc7740f1443.webp" alt="강릉하얀감자탕" class="mw-100">
-            </a>
-        </li>
-        
-        <li class="list-group-item border-0">
-            <a href="https://mj123123.cafe24.com/intking" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/editor/2405/comment_3716871170_F28Rqvax_b69648f787231953208fb7d3573a7d34e73e2cee.gif" alt="인터넷끝판왕" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/bonnemere/products/6780017941" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/editor/2405/comment_3716871170_RBcEJt9s_ef530bc5cfbe76483eebb37ccc02587bee1897c5.gif" alt="데일리셰프" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://buddyback.co.kr/category/%EC%8A%A4%ED%8A%B8%EB%A0%88%EC%B9%AD%EA%B8%B0%EC%96%B4/24/" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/editor/2405/comment_1954376459_8Pp2Jkcx_b61a73f34a8e465c167869757ca2ff23e79aa0e6.gif" alt="버디백" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://1chopick.com/product/list.html?cate_no=61" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/editor/2405/comment_2949741484_hAFuV1z0_8119986b536b8afdd8153ad1a297081d8c22b0e8.webp" alt="일초픽" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/aumu?nt_source=damoang&nt_medium=banner&nt_detail=garo" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/015f0b5e4ca48f7d44e78ebd6f62e722_MJ2tjoQr_644bd3018095322f344c700c8367820d1b18b941.gif" alt="어뮤" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/farmartholic/products/10322631983" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/015f0b5e4ca48f7d44e78ebd6f62e722_dHIuWmft_44800559d7ec84eb2084a7db531b586ef983f5d9.webp" alt="팜아트홀릭" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/skcwindowfilm/products/438041022" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/71b4a9186c9a565849840477974bc730_vjMGQxhl_01e7a118ac11b5222a01471e70dbe10b770d8fa0.gif" alt="올필름" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://content.rview.com/ko/landing-damoang/?utm_source=damoang&utm_medium=cpc&utm_campaign=rvko-lnd-damoang" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/e0c519ad5bcd4d56e72a26556e8d9765_CpVIksYG_09dd2ad3c72c37f55a7939d9b3890a0d6d65598b.gif" alt="알서포트" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/incasalt/products/8749778288" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/3caac7cdc7671dc247c1198f5a901c2c_zXeCDNI3_4fbab496b0bb34e0efdc43c75bbe424cf842f9bc.gif" alt="소금 한 톨" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://m.smartstore.naver.com/byscent_/products/8797786630" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/e0c519ad5bcd4d56e72a26556e8d9765_ObgWrGhA_d4954634c354427885187ae456222982b8ff3ec1.gif" alt="바이센트" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://series.naver.com/novel/detail.series?productNo=10198780" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/e0c519ad5bcd4d56e72a26556e8d9765_hP2mYpg3_718cebcd0b2687fd3c99df8676b9f8037b988b6c.webp" alt="적운창" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/flavorplan/products/7624104583" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/a270a400dee098ccf1d9be8bb45768a0_lt04w9q6_dd9410b32daf4f965c926d77b54c257b9910fd93.gif" alt="플래이버플랜" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-            <a href="https://smartstore.naver.com/ildio" data-dd-action-name="Boards Ads Banner">
-                <img src="https://damoang.net/data/file/banners/5e66ab3f5657fa5d5b92b43e91145d8a_E9Aam2I3_65702721937a30691bf9d8d43bb1f9ac18889b42.gif" alt="일딩오" class="mw-100">
-            </a>
-        </li>
-        <li class="list-group-item border-0">
-          <a href="https://smartstore.naver.com/dingreen" data-dd-action-name="Boards Ads Banner">
-               <img src="https://damoang.net/data/file/banners/015f0b5e4ca48f7d44e78ebd6f62e722_eIEiASdk_ae77791f0b971a127e0c4ea6f9bbba4692a8de02.gif" alt="딩그린" class="mw-100">
-            </a>
-        </li>
-    </ul>
-</section>
+if (!defined('_GNUBOARD_'))
+    exit; //개별 페이지 접근 불가
 
-<!-- 사이드 배너 ----------------------------------------------------------- -->
-<section class="container my-5">
-    <h3 class="border-bottom mb-4 pb-2">사이드 배너</h3>
-    <ul class="text-center row row-cols-2 list-group list-group-horizontal list-group-flush">
-        <li class="col list-group-item border-0">
-            <a href="https://mj123123.cafe24.com/intking" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/editor/2405/comment_3716871170_0XBn5AoL_335c5bc4344705c5f3986db1a223e275b03e9198.gif" alt="인터넷끝판왕" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://smartstore.naver.com/lostone_seoul" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/015f0b5e4ca48f7d44e78ebd6f62e722_KaHgzveh_4dbfb09b1902d5fb477d8e8e988dc9d0ce639d57.webp" alt="로스톤 서울" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://www.griun.co.kr/?utm_source=damoang&utm_medium=banner" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/015f0b5e4ca48f7d44e78ebd6f62e722_uLbzS9tr_ab700a98eaf5bff85b60ce14379e5960bf463b09.webp" alt="그리운 Griun" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://bit.ly/3ymGlEj" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/f28b5896bb5b70ec2e61f0a18713be5a_BehOx5U6_87f0076c5bba3fc00b8d6db96d24ea8bf836ae65.jpg" alt="에어텔닷컴" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://smartstore.naver.com/steady_coffee" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/3caac7cdc7671dc247c1198f5a901c2c_bhOsJ9yj_b07921c2ee45cc8619c0649f940dec64c3bfea4a.jpg" alt="스테디 커피" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://smartstore.naver.com/atelierhaus/products/10382323512" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/e0c519ad5bcd4d56e72a26556e8d9765_CJpub748_8e60b790bef3076042bd66c1807d8fc3340dfada.gif" alt="스트로크컴퍼니" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://smartstore.naver.com/k-young/products/4605987515" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/3caac7cdc7671dc247c1198f5a901c2c_WhdUsIZi_d7df65cb104838cf08fbf90ba21e40e66b370103.gif" alt="스테디 커피" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://qshop.ai/?utm_source=damoang&utm_medium=display" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/editor/669a2-66608a27cc73e-932d5bc69669f8323ae9c0a5b271e21a0723ea2b.jpg" alt="블랙독" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="https://blackdogkorea.com/index.html" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/banners/669a2fdc5df0a62a80ae0c25089c78d8_Ar6xPYEk_b156ab7519de667d6ec93cd676371edd3fd06483.gif" alt="스퀘어스" class="mw-100">
-            </a>
-        </li>
-        <li class="col list-group-item border-0">
-            <a href="#" data-dd-action-name="Sidebar Ads Banner">
-                <img src="https://damoang.net/data/file/main/015f0b5e4ca48f7d44e78ebd6f62e722_okJwxveB_c6b9ed39b9396558318ccdda410aed0e2a1cfdbd.png" alt="스테디 커피" class="mw-100">
-            </a>
-        </li>
-    </ul>
-</section>
+/* 위젯 내용 순서대로 출력.
+-긴배너
+-사이드배너
+-직접홍보
+위젯코드: theme/basic/layout/basic/widget/advertiser */
+echo na_widget('advertiser', 'adCollection'); ?>
 
-<!-- 직접홍보 -------------------------------------------------------------- -->
-<section class="container my-5">
-    <h3 class="border-bottom mb-4 pb-2">
-        직접홍보 게시판
-        <small class="float-end"><a class="btn btn-sm btn-bd-light rounded-2" href="/promotion">🌻바로가기</a></small>
-    </h3>
 
-    <ul class="text-center row row-cols-2 row-cols-md-3 list-group list-group-horizontal list-group-flush" style="font-size: 0.875rem;">
-        <li class="col list-group-item border-0">우리정보통신</li>
-        <li class="col list-group-item border-0">농부가간다</li>
-        <li class="col list-group-item border-0">테라베이</li>
-        <li class="col list-group-item border-0">모스란다</li>
-        <li class="col list-group-item border-0">스테디커피</li>
-        <li class="col list-group-item border-0">법률사무소 메리츠 스카이</li>
-        <li class="col list-group-item border-0">리틀빅애드컨설팅</li>
-        <li class="col list-group-item border-0">진1937</li>
-        <li class="col list-group-item border-0">티달빛</li>
-        <li class="col list-group-item border-0">고도몰</li>
-        <li class="col list-group-item border-0">리에코</li>
-        <li class="col list-group-item border-0">브릭스제주</li>
-        <li class="col list-group-item border-0">로스톤</li>
-        <li class="col list-group-item border-0">그리운 Griun (TYPEE)</li>
-        <li class="col list-group-item border-0">일디오커피로스터스</li>
-        <li class="col list-group-item border-0">씽크와이드</li>
-        <li class="col list-group-item border-0">지피컴퍼니</li>
-        <li class="col list-group-item border-0">(주)알로식품연구소</li>
-        <li class="col list-group-item border-0">강녕상회</li>
-        <li class="col list-group-item border-0">올필름</li>
-        <li class="col list-group-item border-0">젠틀파파</li>
-        <li class="col list-group-item border-0">모찌덕후</li>
-        <li class="col list-group-item border-0">비트리비 서비스</li>
-        <li class="col list-group-item border-0">LG헬로비전</li>
-    </ul>
-</section>
-  
 <!-- 이전 광고  -------------------------------------------------------------- -->
 <section class="container mb-5">
 
-   <h3>다모앙에 도움을 주셨던 이전 광고주님</h3>
-        <ul class="text-center row row-cols-2 row-cols-md-3 list-group list-group-horizontal list-group-flush" style="font-size: 0.875rem;">
+    <h3>다모앙에 도움을 주셨던 이전 광고주님</h3>
+    <ul class="text-center row row-cols-2 row-cols-md-3 list-group list-group-horizontal list-group-flush" style="font-size: 0.875rem;">
+        <!-- <li class="col list-group-item border-0">딩그린(베트남) 긴배너</li> -->
+    </ul>
 
-<!--                     <li class="col list-group-item border-0">딩그린(베트남) 긴배너</li> -->
-
-        </li>
-        
-    
 </section>


### PR DESCRIPTION
광고주모음 페이지인 '광고앙' 페이지를 위한 위젯을 추가하였습니다. 

* 현재의 긴배너와 사이드배너 자동 동기화 출력
현재 광고주 광고 배너 목록을 업데이트하기위해 더이상 php 코드를 수정하지 않아도  헤드배너와 사이드배너 위젯을 통해 등록중인 긴배너와 사이드배너들이 '광고앙'페이지 (/content/advertiser)에 자동으로 나옵니다.

*직홍게 광고주 리스트를 위젯 데이터로 관리
또한 직홍게 리스트를 위젯으로 관리할 수 있습니다. '광고앙' 페이지에서 위젯설정을 눌러보면 '광고주모음 위젯설정' 버튼이 나오고 거기에서 직홍게 광고주 목록을 업데이트 할 수 있습니다. 